### PR TITLE
Fix crash when entry_step was None in FunctionCall

### DIFF
--- a/src/soldb/transaction_tracer.py
+++ b/src/soldb/transaction_tracer.py
@@ -1289,7 +1289,7 @@ class TransactionTracer:
             main_call = FunctionCall(
                 name=main_function_name,
                 selector=main_selector,
-                entry_step=None,  # Will be set later
+                entry_step=0,  # Will be set later
                 exit_step=None,
                 gas_used=0,
                 depth=1,  # Depth 1 since it's under dispatcher


### PR DESCRIPTION
This caused crashed  when the debugger expected an integer step index. The fix initializes entry_step to 0 at creation time.