### PR TITLE
Allow --contracts file while in interactive mode

### DIFF
--- a/src/soldb/main.py
+++ b/src/soldb/main.py
@@ -659,7 +659,7 @@ def interactive_mode(args,tracer):
             print(error(f"Debug session failed: {e}"))
             return 1
     elif is_contract_address:
-        if not args.ethdebug_dir:
+        if not args.ethdebug_dir and not args.contracts:
             print(error("Error: --ethdebug-dir is required when using --contract-address."))
             return 1
         if args.constructor_args:


### PR DESCRIPTION
Fixed a problem when soldb expected ethdebug dir
even when contracts.json file was provided.