### PR TITLE
Improve how we send ethdebug-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ solc --via-ir --debug-info ethdebug --ethdebug --ethdebug-runtime --bin --abi --
 
 Trace a transaction:
 ```bash
-soldb trace <tx_hash> --ethdebug-dir ./out --rpc http://localhost:8545
+soldb trace <tx_hash> --ethdebug-dir <contract_address>:<contract_name>:./out --rpc http://localhost:8545
 ```
 
 ---
@@ -37,7 +37,7 @@ soldb trace <tx_hash> --ethdebug-dir ./out --rpc http://localhost:8545
 ## Example: Debugging a Transaction
 
 ```bash
-soldb trace 0x2832...3994 --ethdebug-dir ./out --rpc http://localhost:8545
+soldb trace 0x2832...3994 --ethdebug-dir 0x3aa5ebb10dc797cac828524e59a333d0a371443c:TestContract:./out --rpc http://localhost:8545
 ```
 
 Output:
@@ -55,7 +55,7 @@ Call Stack:
 
 Interactive mode:
 ```bash
-soldb trace <tx_hash> --ethdebug-dir ./out --rpc http://localhost:8545 --interactive
+soldb trace <tx_hash> --ethdebug-dir <contract_address>:<contract_name>:./out --rpc http://localhost:8545 --interactive
 ```
 
 Inside REPL:
@@ -72,7 +72,7 @@ Inside REPL:
 Test contract functions without sending transactions on chain.
 
 ```bash
-soldb simulate <contract_address> "increment(uint256)" 10 --from <sender_address> --ethdebug-dir ./out --rpc http://localhost:8545
+soldb simulate <contract_address> "increment(uint256)" 10 --from <sender_address> --ethdebug-dir <contract_address>:<contract_name>:./out --rpc http://localhost:8545
 ```
 
 Output containing a simulation failure:
@@ -90,13 +90,13 @@ Call Stack:
 
 You can also pass complex types (structs, tuples):
 ```bash
-soldb simulate <contract_address> "submitPerson((string,uint256))" '("Alice", 30)'     --from <sender_address>     --ethdebug-dir ./out     --rpc http://localhost:8545
+soldb simulate <contract_address> "submitPerson((string,uint256))" '("Alice", 30)'     --from <sender_address>     --ethdebug-dir <contract_address>:<contract_name>:./out     --rpc http://localhost:8545
 ```
 
 You can also debug simulations interactively using the `--interactive` flag:
 
 ```bash
-soldb simulate <contract_address> "increment(uint256)" 5     --from <sender_address>     --ethdebug-dir ./out     --rpc http://localhost:8545     --interactive
+soldb simulate <contract_address> "increment(uint256)" 5     --from <sender_address>     --ethdebug-dir <contract_address>:<contract_name>:./out     --rpc http://localhost:8545     --interactive
 ```
 
 Inside REPL:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,7 +211,7 @@ def analyze_function_calls(trace, ethdebug):
 
 When you run:
 ```bash
-soldb trace 0x35ffb6c4... --ethdebug-dir ./debug --rpc http://localhost:8547
+soldb trace 0x35ffb6c4... --ethdebug-dir 0x3aa5ebb10dc797cac828524e59a333d0a371443c:TestContract:./debug --rpc http://localhost:8547
 ```
 
 The flow is:

--- a/src/soldb/ethdebug_dir_parser.py
+++ b/src/soldb/ethdebug_dir_parser.py
@@ -1,0 +1,148 @@
+"""
+ETHDebug Directory Parser
+
+Handles parsing and validation of ethdebug_dir paths.
+"""
+
+from typing import List, Tuple, Optional, Dict, Any
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+from soldb.colors import error, warning
+
+
+@dataclass
+class ETHDebugSpec:
+    """Represents a parsed ethdebug directory specification."""
+    address: Optional[str] = None
+    name: Optional[str] = None
+    path: str = ""
+    
+    def __post_init__(self):
+        """Validate the parsed specification."""
+        if self.address and not self.address.startswith('0x'):
+            raise ValueError(f"Address must start with '0x': {self.address}")
+        
+        if not self.path:
+            raise ValueError("Path cannot be empty")
+        
+        if not os.path.exists(self.path):
+            raise ValueError(f"Path does not exist: {self.path}")
+
+
+class ETHDebugDirParser:
+    """Parser for ethdebug_dir paths."""
+    
+    @staticmethod
+    def parse_single_contract(ethdebug_spec: str) -> ETHDebugSpec:
+        """
+        Parse single contract ethdebug specification.
+        Expected format: 'address:name:path'
+        
+        Args:
+            ethdebug_spec: The specification string
+            
+        Returns:
+            ETHDebugSpec object with parsed components
+            
+        Raises:
+            ValueError: If the format is invalid
+        """
+        if ':' not in ethdebug_spec or not ethdebug_spec.startswith('0x'):
+            raise ValueError(f"Must use format 'address:name:path' (got: {ethdebug_spec})")
+        
+        parts = ethdebug_spec.split(':', 2)
+        if len(parts) != 3:
+            raise ValueError(f"Must use format 'address:name:path' (got: {ethdebug_spec})")
+        
+        address, name, path = parts
+        
+        # Normalize path
+        path = os.path.normpath(path)
+        
+        return ETHDebugSpec(address=address, name=name, path=path)
+    
+    @staticmethod
+    def parse_multi_contract(ethdebug_spec: str) -> ETHDebugSpec:
+        """
+        Parse multi-contract ethdebug specification.
+        Expected format: 'address:path' or just 'path'
+        
+        Args:
+            ethdebug_spec: The specification string
+            
+        Returns:
+            ETHDebugSpec object with parsed components
+            
+        Raises:
+            ValueError: If the format is invalid
+        """
+        if ':' in ethdebug_spec and ethdebug_spec.startswith('0x'):
+            # Format: address:path
+            parts = ethdebug_spec.split(':', 1)
+            if len(parts) != 2:
+                raise ValueError(f"Must use format 'address:path' (got: {ethdebug_spec})")
+            
+            address, path = parts
+            path = os.path.normpath(path)
+            
+            return ETHDebugSpec(address=address, name=None, path=path)
+        else:
+            # Format: just path
+            path = os.path.normpath(ethdebug_spec)
+            return ETHDebugSpec(address=None, name=None, path=path)
+    
+    @staticmethod
+    def parse_ethdebug_dirs(ethdebug_dirs: List[str]) -> List[ETHDebugSpec]:
+        """
+        Parse a list of ethdebug directory specifications.
+        
+        Args:
+            ethdebug_dirs: List of ethdebug directory specifications in format 'address:name:path'
+            
+        Returns:
+            List of ETHDebugSpec objects
+            
+        Raises:
+            ValueError: If any specification is invalid
+        """
+        if not ethdebug_dirs:
+            return []
+        
+        specs = []
+        for ethdebug_spec in ethdebug_dirs:
+            try:
+                # Always use single contract parser since address:name:path is the only valid format
+                spec = ETHDebugDirParser.parse_single_contract(ethdebug_spec)
+                specs.append(spec)
+            except ValueError as e:
+                raise ValueError(f"Invalid ethdebug specification '{ethdebug_spec}': {e}")
+        
+        return specs
+    
+    @staticmethod
+    def find_abi_file(spec: ETHDebugSpec, contract_name: Optional[str] = None) -> Optional[str]:
+        """
+        Find ABI file for the given specification.
+        
+        Args:
+            spec: The ETHDebugSpec to find ABI for
+            contract_name: Optional contract name to use for ABI file search
+            
+        Returns:
+            Path to ABI file if found, None otherwise
+        """
+        ethdebug_dir = Path(spec.path)
+        
+        # Try contract-specific ABI file first
+        if contract_name:
+            abi_path = ethdebug_dir / f"{contract_name}.abi"
+            if abi_path.exists():
+                return str(abi_path)
+        
+        # Try any ABI file in the directory
+        for abi_file in ethdebug_dir.glob("*.abi"):
+            return str(abi_file)
+        
+        return None

--- a/src/soldb/evm_repl.py
+++ b/src/soldb/evm_repl.py
@@ -27,7 +27,7 @@ Use {info('next')}/{info('nexti')} to step, {info('continue')} to run, {info('wh
                  rpc_url: str = "http://localhost:8545", ethdebug_dir: str = None, constructor_args: List[str] = [],
                  multi_contract_parser = None,function_name: str = None, function_args: List[str] = [],
                  abi_path: str = None, from_addr: str = None, block: int = None,
-                 tracer: TransactionTracer = None):
+                 tracer: TransactionTracer = None, contract_name: str = None):
         super().__init__()
 
         if not tracer:
@@ -38,6 +38,14 @@ Use {info('next')}/{info('nexti')} to step, {info('continue')} to run, {info('wh
         # Set multi-contract parser if provided
         if multi_contract_parser:
             self.tracer.multi_contract_parser = multi_contract_parser
+            # In multi-contract mode, set ethdebug_info to the main contract
+            if contract_address:
+                main_contract = multi_contract_parser.get_contract_at_address(contract_address)
+                if main_contract:
+                    self.tracer.ethdebug_info = main_contract.ethdebug_info
+                    self.tracer.ethdebug_parser = main_contract.parser
+                    # Load source_map from the main contract
+                    self.source_map = main_contract.ethdebug_info.pc_to_line if main_contract.ethdebug_info else {}
         self.current_trace = None
         self.current_step = 0
         self.breakpoints = set()
@@ -74,16 +82,23 @@ Use {info('next')}/{info('nexti')} to step, {info('continue')} to run, {info('wh
         self.abi_path = abi_path
         self.from_addr = from_addr
         self.block = block
+        self.contract_name = contract_name
 
         if self.contract_address and not self.tracer.is_contract_deployed(self.contract_address):
             print(error(f"Error: No contract found at address {self.contract_address}"))
             sys.exit(1)
 
         # Load ETHDebug info if available
-        if ethdebug_dir:
-            if ethdebug_dir.startswith("0x"):
-                ethdebug_dir = ethdebug_dir.split(":")[2]
-            self.source_map = self.tracer.load_ethdebug_info(ethdebug_dir)
+        if ethdebug_dir and not multi_contract_parser:
+            # Use provided contract_name or extract from ethdebug_dir if in address:name:path format
+            if not self.contract_name and ":" in ethdebug_dir and ethdebug_dir.startswith("0x"):
+                parts = ethdebug_dir.split(":")
+                if len(parts) >= 3:
+                    self.contract_name = parts[1]  # Extract name part
+                    ethdebug_dir = parts[2]  # Extract path part
+                elif len(parts) == 2:
+                    ethdebug_dir = parts[1]  # Extract path part
+            self.source_map = self.tracer.load_ethdebug_info(ethdebug_dir, self.contract_name)
             # Load ABI from ethdebug directory
             if self.tracer.ethdebug_info:
                 abi_path = os.path.join(ethdebug_dir, f"{self.tracer.ethdebug_info.contract_name}.abi")
@@ -119,12 +134,24 @@ Use {info('next')}/{info('nexti')} to step, {info('continue')} to run, {info('wh
     def _load_source_files(self):
         """Load all source files referenced in debug info."""
         if self.tracer.ethdebug_info:
-            # Load from ETHDebug sources
+            # Load from ETHDebug sources - only load the main contract source
+            main_contract_source = None
             for source_id, source_path in self.tracer.ethdebug_info.sources.items():
-                lines = self.tracer.ethdebug_parser.load_source_file(source_path)
+                # Find the main contract source (usually the one that matches contract name)
+                if self.tracer.ethdebug_info.contract_name.lower() in source_path.lower():
+                    main_contract_source = source_path
+                    break
+            
+            if main_contract_source:
+                lines = self.tracer.ethdebug_parser.load_source_file(main_contract_source)
                 if lines:
-                    self.source_lines[source_path] = lines
-                    print(f"Loaded source: {info(os.path.basename(source_path))}")
+                    self.source_lines[main_contract_source] = lines
+            else:
+                # Fallback: load all sources
+                for source_id, source_path in self.tracer.ethdebug_info.sources.items():
+                    lines = self.tracer.ethdebug_parser.load_source_file(source_path)
+                    if lines:
+                        self.source_lines[source_path] = lines
         elif self.debug_file:
             # Extract source file from debug file name
             source_file = self.debug_file.split('_')[0]

--- a/src/soldb/multi_contract_ethdebug_parser.py
+++ b/src/soldb/multi_contract_ethdebug_parser.py
@@ -11,6 +11,8 @@ from typing import Dict, List, Optional, Tuple, Any, Union
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from soldb.colors import warning
+
 from .ethdebug_parser import ETHDebugParser, ETHDebugInfo, SourceLocation, Instruction, VariableLocation
 from eth_utils import to_checksum_address
 
@@ -76,6 +78,7 @@ class MultiContractETHDebugParser:
         # Create a parser for this contract
         parser = ETHDebugParser()
         parser.source_cache = self.source_cache  # Share source cache
+        parser.debug_dir = str(debug_dir)  # Set debug_dir for source loading
         
         # Load ETHDebug info
         ethdebug_info = parser.load_ethdebug_files(debug_dir, contract_name)
@@ -135,9 +138,9 @@ class MultiContractETHDebugParser:
                     contract_debug_info = self.load_contract(address, debug_dir, contract_name)
                     loaded_contracts[address] = contract_debug_info
                 except Exception as e:
-                    print(f"Warning: Failed to load debug info for {contract_name}: {e}")
+                    print(warning(f"Warning: Failed to load debug info for {contract_name}: {e}"))
             else:
-                print(f"Warning: ETHDebug not enabled for {contract_name}")
+                print(warning(f"Warning: ETHDebug not enabled for {contract_name}"))
         
         # Also handle multi-contract format if present
         elif 'contracts' in deployment_data:
@@ -167,7 +170,7 @@ class MultiContractETHDebugParser:
                             contract_debug_info = self.load_contract(address, debug_dir, contract_name)
                             loaded_contracts[address] = contract_debug_info
                         except Exception as e:
-                            print(f"Warning: Failed to load debug info for {contract_name}: {e}")
+                            print(warning("Warning: Failed to load debug info for {contract_name}: {e}"))
                     else:
                         print(f"Warning: No debug directory found for {contract_name}")
         
@@ -210,7 +213,7 @@ class MultiContractETHDebugParser:
                 contract_debug_info = self.load_contract(address, debug_dir, name)
                 loaded_contracts[address] = contract_debug_info
             except Exception as e:
-                print(f"Warning: Failed to load contract {name} at {address}: {e}")
+                print(warning("Warning: Failed to load contract {name} at {address}: {e}"))
         
         return loaded_contracts
     

--- a/src/soldb/source_file_loader.py
+++ b/src/soldb/source_file_loader.py
@@ -1,0 +1,103 @@
+"""
+Centralized source file loader to avoid duplicate loading and warnings.
+"""
+
+from typing import Dict, List, Optional
+from pathlib import Path
+import os
+
+from soldb.colors import warning
+
+
+class SourceFileLoader:
+    """Centralized source file loader with global cache."""
+    
+    _instance = None
+    _source_cache: Dict[str, List[str]] = {}
+    _warning_shown: set = set()
+    
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+    
+    def load_source_file(self, source_path: str, debug_dir: Optional[str] = None) -> List[str]:
+        """Load and cache source file lines globally."""
+        if source_path not in self._source_cache:
+            result = self._find_and_load_source_file(source_path, debug_dir)
+            self._source_cache[source_path] = result
+            
+            # Show warning only if file was not found 
+            if not result and source_path not in self._warning_shown:
+                self._warning_shown.add(source_path)
+                print(warning(f"Warning: Source file not found: {source_path}"))
+        
+        return self._source_cache[source_path]
+    
+    def _find_and_load_source_file(self, source_path: str, debug_dir: Optional[str] = None) -> List[str]:
+        """Find and load a source file using simplified pattern."""
+        # Try direct path first
+        result = self._try_load_file(Path(source_path))
+        if result:
+            return result
+        
+        # Find root project directory (where out/ folder is generated)
+        root_project_dir = self._find_root_project_directory()
+        if root_project_dir:
+            # Resolve source path relative to root project
+            full_source_path = root_project_dir / source_path
+            result = self._try_load_file(full_source_path)
+            if result:
+                return result
+        
+        # Try walking up the directory hierarchy from debug directory
+        if debug_dir:
+            current_dir = Path(debug_dir)
+            filename = os.path.basename(source_path)
+            
+            # Try current debug directory and go up the hierarchy
+            for _ in range(2):  # Limit to 2 levels up
+                # Try current directory
+                test_path = current_dir / source_path
+                result = self._try_load_file(test_path)
+                if result:
+                    return result
+                
+                # Try just the filename in current directory
+                test_path = current_dir / filename
+                result = self._try_load_file(test_path)
+                if result:
+                    return result
+                
+                # Move up one directory
+                parent = current_dir.parent
+                if parent == current_dir:  # Reached root
+                    break
+                current_dir = parent
+        
+        # Not found
+        return []
+    
+    def _find_root_project_directory(self) -> Optional[Path]:
+        """Find the root project directory - assume out/ is in current directory."""
+        current_dir = Path.cwd()
+        out_dir = current_dir / "out"
+        
+        if out_dir.exists() and out_dir.is_dir():
+            return current_dir
+        
+        return None
+    
+    def _try_load_file(self, file_path: Path) -> Optional[List[str]]:
+        """Try to load a file and return its contents or None if failed."""
+        if file_path.exists() and file_path.is_file():
+            try:
+                with open(file_path) as f:
+                    return f.readlines()
+            except (IsADirectoryError, PermissionError, UnicodeDecodeError) as e:
+                print(warning(f"Warning: Cannot read source file {file_path}: {e}"))
+        return None
+
+
+# Global instance
+source_loader = SourceFileLoader()

--- a/test/deploy-contract.sh
+++ b/test/deploy-contract.sh
@@ -336,4 +336,4 @@ EOF
 echo -e "\n${GREEN}Deployment complete!${NC}"
 echo -e "\n${BLUE}ETHDebug files location:${NC} $DEBUG_DIR"
 echo -e "\n${BLUE}To trace with ETHDebug:${NC}"
-echo -e "  soldb trace $TX_HASH --ethdebug-dir $DEBUG_DIR --rpc $RPC_URL"
+echo -e "  soldb trace $TX_HASH --ethdebug-dir $CONTRACT_ADDR:$CONTRACT_NAME:$DEBUG_DIR --rpc $RPC_URL"

--- a/test/interact-contract.sh
+++ b/test/interact-contract.sh
@@ -26,7 +26,14 @@ get_debug_command() {
     
     # Check if ethdebug format is available
     if [ -f "$abs_debug_dir/ethdebug.json" ]; then
-        echo "soldb trace $tx_hash --ethdebug-dir $abs_debug_dir --rpc $RPC_URL"
+        # Get contract address and name from deployment.json
+        if [ -f "$abs_debug_dir/deployment.json" ]; then
+            CONTRACT_ADDR=$(jq -r '.address' "$abs_debug_dir/deployment.json")
+            CONTRACT_NAME=$(jq -r '.contract' "$abs_debug_dir/deployment.json")
+            echo "soldb trace $tx_hash --ethdebug-dir $CONTRACT_ADDR:$CONTRACT_NAME:$abs_debug_dir --rpc $RPC_URL"
+        else
+            echo "soldb trace $tx_hash --rpc $RPC_URL"
+        fi
     else
         # Default to simple trace without debug info
         echo "soldb trace $tx_hash --rpc $RPC_URL"

--- a/test/simulate/basic-simulate.test
+++ b/test/simulate/basic-simulate.test
@@ -1,7 +1,7 @@
 # Test basic soldb simulate functionality
 # REQUIRES: soldb
 # First deploy the contract, then simulate a function call
-# RUN: %soldb simulate %{contract_address} "increment(uint256)" 4 --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethdebug-dir %{ethdebug_dir} --rpc %{rpc_url} 2>&1 | FileCheck %s
+# RUN: %soldb simulate %{contract_address} "increment(uint256)" 4 --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethdebug-dir %{contract_address}:TestContract:%{ethdebug_dir} --rpc %{rpc_url} 2>&1 | FileCheck %s
 
 # Check that we get the basic simulation output structure
 # CHECK: Contract: TestContract

--- a/test/simulate/interactive-simulate.test
+++ b/test/simulate/interactive-simulate.test
@@ -1,7 +1,7 @@
 # Test soldb simulate interactive mode
 # REQUIRES: soldb
 # Simulate a function call in interactive mode
-# RUN: echo "quit" | %soldb simulate %{contract_address} "increment(uint256)" 4 --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethdebug-dir %{ethdebug_dir} --rpc %{rpc_url} -i 2>&1 | FileCheck %s
+# RUN: echo "quit" | %soldb simulate %{contract_address} "increment(uint256)" 4 --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethdebug-dir %{contract_address}:TestContract:%{ethdebug_dir} --rpc %{rpc_url} -i 2>&1 | FileCheck %s
 
 # Check that we get the basic simulation output structure
 # CHECK: Contract: TestContract

--- a/test/simulate/json-simulate.test
+++ b/test/simulate/json-simulate.test
@@ -1,7 +1,7 @@
 # Test JSON output functionality for simulate command
 # REQUIRES: soldb
 # First deploy the contract, then simulate a function call with --json flag
-# RUN: %soldb simulate %{contract_address} "increment(uint256)" 4 --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethdebug-dir %{ethdebug_dir} --rpc %{rpc_url} --json 2>&1 | FileCheck %s
+# RUN: %soldb simulate %{contract_address} "increment(uint256)" 4 --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethdebug-dir %{contract_address}:TestContract:%{ethdebug_dir} --rpc %{rpc_url} --json 2>&1 | FileCheck %s
 
 # When using --json flag, we should get valid JSON output
 # CHECK: {

--- a/test/simulate/multi-contract-simulate-sepolia.test
+++ b/test/simulate/multi-contract-simulate-sepolia.test
@@ -1,0 +1,50 @@
+# Test multi-contract simulation functionality
+# REQUIRES: soldb
+# RUN: %soldb simulate 0x59A714559B46c823d87986b5c5B7C630e2f5668d "processOrder(uint256,string,string)" 10 "express" "electronic" --from 0x286AF310eA3303c80eBE9a66F6998B21Bd8c1c29 --rpc %{sepolia_rpc_url} --ethdebug-dir 0x6a85ebf0Eba5307943bDF27D02d198Bc64e9ffEd:TaxCalculator:%{project_root}/test/walnut_0x75964ba0087ff8ae69bd7c17c8c4db66bc0c8e75603f79de1265c61ddfd98f2e_1756985337815_2zvewt/0x6a85ebf0Eba5307943bDF27D02d198Bc64e9ffEd/debug --ethdebug-dir 0xbE734aD6434E16f6bE04706005faED6fD38eb2B2:ShippingManager:%{project_root}/test/walnut_0x75964ba0087ff8ae69bd7c17c8c4db66bc0c8e75603f79de1265c61ddfd98f2e_1756985337815_2zvewt/0xbE734aD6434E16f6bE04706005faED6fD38eb2B2/debug 2>&1 | FileCheck %s
+
+# CHECK: Function Call Trace: None
+# CHECK:   TaxCalculator (0x6a85ebf0Eba5307943bDF27D02d198Bc64e9ffEd)
+# CHECK:   ShippingManager (0xbE734aD6434E16f6bE04706005faED6fD38eb2B2)
+# CHECK: Gas used: 83413
+# CHECK: Status: SUCCESS
+
+# Check for the call stack header
+# CHECK: Call Stack:
+# CHECK:------------------------------------------------------------
+
+# Check that we see the main function call with parameters
+# CHECK: #0 Contract::runtime_dispatcher [entry] [non-verified] gas: 61189 @ Contract entry point
+# CHECK:  #1 function_0x6f10e157 [0x6f10e157] [external] [non-verified] gas: 61189
+# CHECK:     arguments: 0x000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000076578707265737300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a656c656374726f6e696300000000000000000000000000000000000000000000
+
+# Check for internal function calls to other contracts
+# CHECK:    #2 CALL → 0xdcDd...Ac0A::log(string) [0x41304fac] [CALL] [non-verified] gas:
+# CHECK:       arguments: 0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000195374617274696e67206f726465722070726f63657373696e6700000000000000
+
+# CHECK:    #3 CALL → TaxCalculator::calculateTax(uint256,string) [0x55ec8a03] [CALL] → TaxCalculator gas:
+# CHECK:       value: 10
+# CHECK:       orderType: express
+# CHECK:      #4 calculateTax [internal] gas: -144115188075809365 @ TaxCalculator.sol:7
+# CHECK:         value: 10
+# CHECK:         orderType: express
+# CHECK:        #5 getBaseRate [internal] gas: 3433 @ TaxCalculator.sol:18
+
+# CHECK:    #7 CALL → ShippingManager::initiateShipping(address,string) [0x01567ce2] [CALL] → ShippingManager gas:
+# CHECK:       customer: 0x286AF310eA3303c80eBE9a66F6998B21Bd8c1c29
+# CHECK:       method: electronic
+# CHECK:        #8 initiateShipping [internal] gas: -144115188075822559 @ ShippingManager.sol:8
+# CHECK:           customer: 0x286AF310eA3303c80eBE9a66F6998B21Bd8c1c29
+# CHECK:           method: electronic
+# CHECK:          #9 estimateShipping [internal] gas: 2897 @ ShippingManager.sol:17
+
+# Check for payment processing
+# CHECK:    #11 CALL → 0xf776...1823::processPayment(address,uint256) [0x0b63fe95] [CALL] [non-verified] gas:
+# CHECK:       arguments: 0x000000000000000000000000286af310ea3303c80ebe9a66f6998b21bd8c1c29000000000000000000000000000000000000000000000000000000000000000b
+
+# Check for logging calls
+# CHECK:    #12 CALL → 0xdcDd...Ac0A::function_0xe4af64b1 [0xe4af64b1] [CALL] [non-verified] gas:
+# CHECK:       arguments: 0x0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000e4f7264657220636f6d706c657465000000000000000000000000000000000000
+
+# Check for the footer
+# CHECK:------------------------------------------------------------
+# CHECK: Use --raw flag to see detailed instruction trace

--- a/test/simulate/multi-contract-simulate-sepolia.test
+++ b/test/simulate/multi-contract-simulate-sepolia.test
@@ -1,5 +1,5 @@
 # Test multi-contract simulation functionality
-# REQUIRES: soldb
+# REQUIRES: soldb, sepolia-rpc
 # RUN: %soldb simulate 0x59A714559B46c823d87986b5c5B7C630e2f5668d "processOrder(uint256,string,string)" 10 "express" "electronic" --from 0x286AF310eA3303c80eBE9a66F6998B21Bd8c1c29 --rpc %{sepolia_rpc_url} --ethdebug-dir 0x6a85ebf0Eba5307943bDF27D02d198Bc64e9ffEd:TaxCalculator:%{project_root}/test/walnut_0x75964ba0087ff8ae69bd7c17c8c4db66bc0c8e75603f79de1265c61ddfd98f2e_1756985337815_2zvewt/0x6a85ebf0Eba5307943bDF27D02d198Bc64e9ffEd/debug --ethdebug-dir 0xbE734aD6434E16f6bE04706005faED6fD38eb2B2:ShippingManager:%{project_root}/test/walnut_0x75964ba0087ff8ae69bd7c17c8c4db66bc0c8e75603f79de1265c61ddfd98f2e_1756985337815_2zvewt/0xbE734aD6434E16f6bE04706005faED6fD38eb2B2/debug 2>&1 | FileCheck %s
 
 # CHECK: Function Call Trace: None

--- a/test/simulate/raw-data-simulate.test
+++ b/test/simulate/raw-data-simulate.test
@@ -1,7 +1,7 @@
 # Test raw data simulation functionality
 # REQUIRES: soldb
 # First deploy the contract, then simulate with raw calldata
-# RUN: %soldb simulate %{contract_address} --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethdebug-dir %{ethdebug_dir} --rpc %{rpc_url} --raw-data 0x7cf5dab00000000000000000000000000000000000000000000000000000000000000004 2>&1 | FileCheck %s
+# RUN: %soldb simulate %{contract_address} --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethdebug-dir %{contract_address}:TestContract:%{ethdebug_dir} --rpc %{rpc_url} --raw-data 0x7cf5dab00000000000000000000000000000000000000000000000000000000000000004 2>&1 | FileCheck %s
 
 # Check that we get the basic simulation output structure with raw data
 # CHECK: Contract: TestContract

--- a/test/simulate/raw-simulate.test
+++ b/test/simulate/raw-simulate.test
@@ -1,7 +1,7 @@
 # Test raw instruction trace functionality for simulate command
 # REQUIRES: soldb
 # First deploy the contract, then simulate a function call with --raw flag
-# RUN: %soldb simulate %{contract_address} "increment(uint256)" 4 --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethdebug-dir %{ethdebug_dir} --rpc %{rpc_url} --raw 2>&1 | FileCheck %s
+# RUN: %soldb simulate %{contract_address} "increment(uint256)" 4 --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethdebug-dir %{contract_address}:TestContract:%{ethdebug_dir} --rpc %{rpc_url} --raw 2>&1 | FileCheck %s
 
 # When using --raw flag, we should see individual EVM instructions
 # CHECK: Contract: TestContract

--- a/test/trace/basic-trace.test
+++ b/test/trace/basic-trace.test
@@ -1,6 +1,6 @@
 # Test basic soldb tracing functionality
 # REQUIRES: soldb
-# RUN: %soldb trace %{test_tx} --ethdebug-dir %{ethdebug_dir} --rpc %{rpc_url} 2>&1 | FileCheck %s
+# RUN: %soldb trace %{test_tx} --ethdebug-dir %{contract_address}:TestContract:%{ethdebug_dir} --rpc %{rpc_url} 2>&1 | FileCheck %s
 
 # Check that we get the basic tracing output structure
 # CHECK: Loading transaction

--- a/test/trace/increment-trace.test
+++ b/test/trace/increment-trace.test
@@ -1,7 +1,7 @@
 # Test tracing of increment function call
 # REQUIRES: soldb
 # First deploy the contract, then send an increment transaction, then trace it
-# RUN: cd %S/../examples && rm -rf out && %S/deploy-contract.sh --solc=%{solc_path} --rpc=%{rpc_url} TestContract TestContract.sol --debug-dir=out >/dev/null 2>&1 && TX=$(DEBUG_DIR=out RPC_URL=%{rpc_url} %S/interact-contract.sh send "increment(uint256)" 4 2>&1 | grep -o '0x[a-fA-F0-9]\{64\}' | head -1) && %soldb trace $TX --ethdebug-dir %S/../examples/out --rpc %{rpc_url} 2>&1 | FileCheck %s
+# RUN: cd %S/../examples && rm -rf out && %S/deploy-contract.sh --solc=%{solc_path} --rpc=%{rpc_url} TestContract TestContract.sol --debug-dir=out >/dev/null 2>&1 && CONTRACT_ADDR=$(cat out/deployment.json | jq -r '.address') && TX=$(DEBUG_DIR=out RPC_URL=%{rpc_url} %S/interact-contract.sh send "increment(uint256)" 4 2>&1 | grep -o '0x[a-fA-F0-9]\{64\}' | head -1) && %soldb trace $TX --ethdebug-dir $CONTRACT_ADDR:TestContract:%S/../examples/out --rpc %{rpc_url} 2>&1 | FileCheck %s
 
 # Check for the specific function calls we expect
 # CHECK: Loading transaction

--- a/test/trace/raw-trace.test
+++ b/test/trace/raw-trace.test
@@ -1,6 +1,6 @@
 # Test raw instruction trace functionality
 # REQUIRES: soldb
-# RUN: %soldb trace %{test_tx} --ethdebug-dir %{ethdebug_dir} --rpc %{rpc_url} --raw 2>&1 | FileCheck %s
+# RUN: %soldb trace %{test_tx} --ethdebug-dir %{contract_address}:TestContract:%{ethdebug_dir} --rpc %{rpc_url} --raw 2>&1 | FileCheck %s
 
 # When using --raw flag, we should see individual EVM instructions
 # CHECK: Loading transaction


### PR DESCRIPTION
- Allow simulate to work without ETHDebug info for entrypoint contract
- Load ABIs for all contracts in multi-contract mode
- Prevent crashes when entrypoint contract is not found in interactive mode
- Use relative path resolution from debug directory
- Improve source file resolution in ethdebug_parser.py, in case multi sources in ethdebug.json
- All tests now use the new address:name:path format for --ethdebug-dir parameter
- Added test for multi simulation