### PR TITLE
Fix placeholder author and URLs in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A powerful debugger for Solidity transactions on the Ethereum blockchain"
 readme = "README.md"
 authors = [
-    {name = "Your Name", email = "your.email@example.com"}
+    {name = "Walnut", email = "hi@walnut.dev"}
 ]
 license = {text = "MIT"}
 classifiers = [
@@ -44,10 +44,10 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yourusername/soldb"
-Documentation = "https://github.com/yourusername/soldb#readme"
-Repository = "https://github.com/yourusername/soldb.git"
-Issues = "https://github.com/yourusername/soldb/issues"
+Homepage = "https://github.com/walnuthq/soldb"
+Documentation = "https://github.com/walnuthq/soldb#readme"
+Repository = "https://github.com/walnuthq/soldb.git"
+Issues = "https://github.com/walnuthq/soldb/issues"
 
 [project.scripts]
 soldb = "soldb.cli.main:main"


### PR DESCRIPTION
## Summary

- Replace `"Your Name"` / `"your.email@example.com"` with the correct Walnut author entry
- Replace all `yourusername` GitHub URLs with the correct `walnuthq` org URLs

These are template leftovers that would be visible to anyone inspecting the package on PyPI.