### PR TITLE
Fix license declaration in pyproject.toml (MIT → GPL-3.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ readme = "README.md"
 authors = [
     {name = "Your Name", email = "your.email@example.com"}
 ]
-license = {text = "MIT"}
+license = {text = "GPL-3.0-only"}
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Debuggers",
     "Topic :: Software Development :: Testing",
     "Topic :: System :: Monitoring",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## Summary

`LICENSE.md` contains the full GPL-3.0 text and the README states GPL-3.0, but `pyproject.toml` incorrectly declared `MIT` in both the `license` field and the PyPI classifier.

- `license = {text = "MIT"}` → `{text = "GPL-3.0-only"}`
- Classifier updated to `GNU General Public License v3 (GPLv3)`