### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Email **hi@walnut.dev** with a description of the issue. We will respond as quickly as possible.


### PR DESCRIPTION
## Summary

Adds a minimal security policy directing vulnerability reports to hi@walnut.dev rather than public GitHub issues. GitHub surfaces this file automatically in the Security tab.