### PR TITLE
Fix broken script paths in Makefile test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,13 @@ dev:
 	pip install -r requirements.txt
 
 test:
-	./run-tests.sh
+	./test/run-tests.sh
 
 test-setup:
-	./test-setup.sh
+	./test/test-setup.sh
 
 test-deploy:
-	./test-setup.sh --deploy-test
+	./test/test-setup.sh --deploy-test
 
 publish:
 	./scripts/publish-pypi.sh


### PR DESCRIPTION
## Summary
- The `test`, `test-setup`, and `test-deploy` Makefile targets pointed at `./run-tests.sh` and `./test-setup.sh` at the repo root, but those scripts actually live under `test/`. Any of these targets failed with `no such file or directory`.
- Updated the paths to `./test/run-tests.sh` and `./test/test-setup.sh` so the Makefile shortcuts work.

## Test plan
- [x] `make -n test test-setup test-deploy` shows the corrected paths
- [x] `./test/run-tests.sh --help` runs from the repo root (scripts use `BASH_SOURCE[0]` to resolve their own location, so cwd doesn't matter)
- [x] `./test/test-setup.sh` executes from the repo root without path errors
- [x] Confirmed the old `./run-tests.sh` path returns `no such file or directory` (exit 127), reproducing the bug being fixed