### PR TITLE
Fix .gitignore silently ignoring entire examples/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,3 @@ test/Output/
 test/lit.site.cfg.py
 .soldb_cache/
 .DS_Store
-
-examples/


### PR DESCRIPTION
## Summary

The bare `examples/` rule at the end of `.gitignore` matched the whole directory of tracked example contracts, making the more specific patterns above (`examples/debug/`, `examples/debug*/`, `examples/test_debug/`) redundant and causing any newly added example file to be silently excluded from `git add`.

This drops the over-broad rule and restores the trailing newline that was missing.

## Verification

Existing tracked files in `examples/` (Counter.sol, Ballot.sol, multi_contract/, etc.) are unaffected — they remain tracked. Verified with `git check-ignore`:

- `examples/NewContract.sol` — no longer ignored (was the bug)
- `examples/test_debug/foo` — still ignored via `examples/test_debug/`
- `examples/debug/y` — still ignored via `examples/debug*/`
- `cache/x`, `.DS_Store` — still ignored

## Test plan

- [x] `git check-ignore -v` confirms specific debug/test patterns still match
- [x] `git check-ignore` confirms new example sources are no longer ignored
- [x] No tracked files are removed or affected