### PR TITLE
Add timeout to 4byte.directory event-signature lookup

### DIFF
--- a/src/soldb/utils/helpers.py
+++ b/src/soldb/utils/helpers.py
@@ -195,7 +195,7 @@ def decode_event_log(tracer, log_entry: Dict[str, Any]) -> Dict[str, Any]:
                 text_signature = None
                 event_name = "Unknown"
                 try:
-                    r = requests.get(f"https://www.4byte.directory/api/v1/event-signatures/?hex_signature={event_hash}")
+                    r = requests.get(f"https://www.4byte.directory/api/v1/event-signatures/?hex_signature={event_hash}", timeout=5)
                     response_data = r.json()
                     
                     if 'results' in response_data and response_data['results']:


### PR DESCRIPTION
## Summary

The `requests.get` call to 4byte.directory in `decode_event_log` (`src/soldb/utils/helpers.py:198`) had no `timeout`, so a slow or unresponsive API could hang soldb indefinitely while decoding events on a transaction with unknown event signatures.

The two other 4byte/OpenChain lookups in `src/soldb/core/transaction_tracer.py` (lines 1271, 1289) already pass `timeout=5`; this aligns the third call with the same value.

## Why this is safe

The call is already wrapped in a bare `try/except Exception: pass` block (helpers.py:197/207), so a `requests.Timeout` is handled the same as any other failure: the function falls back to the heuristic param decoding below it. No new failure mode is introduced.

## Test plan

- [x] `python3 -m compileall src/soldb/utils/helpers.py` succeeds
- [x] Diff is a single-line `, timeout=5` addition; control flow unchanged