### PR TITLE
Replace bare except in cli/trace, core/evm_repl, core/serializer

### DIFF
--- a/src/soldb/cli/trace.py
+++ b/src/soldb/cli/trace.py
@@ -162,7 +162,7 @@ def _extract_error_detail(trace_error: str) -> Optional[str]:
             error_dict = ast.literal_eval(trace_error)
             if isinstance(error_dict, dict) and 'message' in error_dict:
                 return error_dict['message']
-    except:
+    except (ValueError, SyntaxError):
         pass
     
     return trace_error

--- a/src/soldb/core/evm_repl.py
+++ b/src/soldb/core/evm_repl.py
@@ -454,7 +454,7 @@ Use {info('next')} to step to next source line, {info('step')} to step into cont
             try:
                 import json
                 return json.loads(arg)
-            except:
+            except json.JSONDecodeError:
                 return arg
     
     def do_nexti(self, arg):

--- a/src/soldb/core/serializer.py
+++ b/src/soldb/core/serializer.py
@@ -90,7 +90,7 @@ class TraceSerializer:
                                         data = "0x" + memory_data
                                     else:
                                         data = "0x" + "00" * safe_size
-                            except:
+                            except Exception:
                                 data = "0x" + "00" * safe_size
                         else:
                             data = "0x" + "00" * safe_size


### PR DESCRIPTION
## Summary

Bare `except:` swallows `KeyboardInterrupt` and `SystemExit` in addition to real errors. Prior PRs (#76 `parsers/dwarf.py`, #77 `utils/helpers.py`) already cleaned this up in two files; three more spots were missed.

| file | before | after | rationale |
|------|--------|-------|-----------|
| `cli/trace.py:165` | `except:` | `except (ValueError, SyntaxError):` | These are exactly what `ast.literal_eval` raises. |
| `core/evm_repl.py:457` | `except:` | `except json.JSONDecodeError:` | The only failure of `json.loads` we care about. |
| `core/serializer.py:93` | `except:` | `except Exception:` | Memory-slice failures are open-ended (`IndexError`/`TypeError`/`ValueError`); follows the `helpers.py` precedent set in #77. |

Failure-path behavior is byte-for-byte unchanged in all three cases.

## Test plan

- [x] `python3 -m compileall src/soldb/cli/trace.py src/soldb/core/evm_repl.py src/soldb/core/serializer.py` exits 0
- [x] Diff is exactly three one-line changes; no other lines touched