### PR TITLE
Fix Colors.enable() so it actually restores codes after a disable()

### DIFF
--- a/src/soldb/utils/colors.py
+++ b/src/soldb/utils/colors.py
@@ -69,8 +69,14 @@ class Colors:
     @classmethod
     def enable(cls):
         """Re-enable colors."""
-        cls.__init__()
+        for attr, value in cls._DEFAULTS.items():
+            setattr(cls, attr, value)
 
+
+# Snapshot the original codes so enable() can restore them after a disable().
+Colors._DEFAULTS = {
+    a: getattr(Colors, a) for a in dir(Colors) if a.isupper() and not a.startswith('_')
+}
 
 # Disable colors if not supported
 if not SUPPORTS_COLOR:

--- a/test/unit/test_utils_colors.py
+++ b/test/unit/test_utils_colors.py
@@ -91,9 +91,23 @@ def test_disable_zeroes_every_color_code_and_helpers_become_passthrough():
         _restore_color_attrs(snapshot)
 
 
-def test_enable_currently_raises_type_error():
-    # `Colors.enable()` calls `cls.__init__()` which dispatches to
-    # `object.__init__` and raises TypeError because no instance is passed.
-    # Captured here so a future fix flips this assertion intentionally.
-    with pytest.raises(TypeError):
+def test_enable_restores_defaults_after_disable():
+    snapshot = _snapshot_color_attrs()
+    try:
+        Colors.disable()
+        assert Colors.RED == ""
+        assert Colors.RESET == ""
+
         Colors.enable()
+        # `enable()` restores from `_DEFAULTS`, which was snapshotted at
+        # module load before the conditional `if not SUPPORTS_COLOR` blank,
+        # so the originals come back regardless of whether the test
+        # process was attached to a TTY.
+        assert Colors.RED == "\033[31m"
+        assert Colors.RESET == "\033[0m"
+        assert Colors.BOLD == "\033[1m"
+        # And every attr matches what `_DEFAULTS` records.
+        for attr in snapshot:
+            assert getattr(Colors, attr) == Colors._DEFAULTS[attr]
+    finally:
+        _restore_color_attrs(snapshot)


### PR DESCRIPTION
## Summary

Stacked on top of #98. Fixes the latent bug that PR uncovered: `Colors.enable()` called `cls.__init__()`, which dispatches to `object.__init__` without an instance and raised `TypeError` instead of restoring the ANSI codes. Once colors were disabled — either by the import-time `if not SUPPORTS_COLOR: Colors.disable()` on a non-TTY stdout, or by an explicit `Colors.disable()` call — there was no way back.

## Fix

Snapshot the original codes into `Colors._DEFAULTS` right after the class is defined and before the conditional disable, and have `enable()` reapply them:

```python
@classmethod
def enable(cls):
    for attr, value in cls._DEFAULTS.items():
        setattr(cls, attr, value)


Colors._DEFAULTS = {
    a: getattr(Colors, a) for a in dir(Colors) if a.isupper() and not a.startswith('_')
}
```

The snapshot is taken before the import-time disable runs, so `enable()` brings colors back to a usable state regardless of TTY detection at import time.

## Test update

The test added in #98 (`test_enable_currently_raises_type_error`) is rewritten to assert correct behavior: after `disable()` blanks the codes and `enable()` is called, every uppercase attr matches `Colors._DEFAULTS`, and the concrete ANSI escapes (`RED`, `RESET`, `BOLD`) come back to their literal values.

## Test plan

- [x] `pytest test/unit/test_utils_colors.py` — 7 tests pass (including the rewritten `test_enable_restores_defaults_after_disable`)
- [x] `pytest test/unit` (full suite) — 55 tests pass
- [x] Manual sanity: `Colors.disable(); Colors.enable()` — `Colors.RED` round-trips to `'\033[31m'`

## Note for reviewers

PR base is `rm/test-utils-colors` (#98) so this PR shows only the fix + test-assertion flip. Once #98 merges, this PR's base auto-rebases to `main` and presents the same two-file diff against main.