### PR TITLE
Remove dead first definition of register_stylus_contract

### DIFF
--- a/src/soldb/core/transaction_tracer.py
+++ b/src/soldb/core/transaction_tracer.py
@@ -220,29 +220,6 @@ class TransactionTracer:
             self.stylus_bridge = None
             return False
 
-    def register_stylus_contract(self, address: str, name: str, lib_path: str) -> bool:
-        """
-        Register a Stylus contract with the bridge.
-
-        Args:
-            address: Contract address
-            name: Contract name
-            lib_path: Path to the contract's shared library (.so file)
-
-        Returns:
-            True if registration was successful
-        """
-        if not self.stylus_bridge or not self.stylus_bridge.is_connected:
-            return False
-
-        contract = ContractInfo(
-            address=address,
-            name=name,
-            environment="stylus",
-            lib_path=lib_path
-        )
-        return self.stylus_bridge.register_contract(contract)
-
     def is_stylus_contract(self, address: str) -> bool:
         """Check if an address is a registered Stylus contract."""
         if not self.stylus_bridge or not self.stylus_bridge.is_connected:


### PR DESCRIPTION
## Summary
- `pyflakes` flagged a duplicate definition of `TransactionTracer.register_stylus_contract` — the first (lines 223–244) was shadowed by a second one further down in the same class.
- Python silently used the second; the first was dead code. Removing it eliminates the warning and a small source of confusion when navigating the file.

## Details
- The surviving definition has the more permissive signature `lib_path: Optional[str] = None`, so it handles all current callers (`cli/trace.py`, `cli/simulate.py`) identically — both pass a non-None string positionally.
- Behavior is unchanged: the second definition was already the only one being executed.

## Test plan
- [x] `pytest test/unit` — 247 passing
- [x] `pytest test/unit test/integration` — 248 passing (incl. `test/integration/test_repl_and_tracer.py::test_register_stylus_contract`)
- [x] `pyflakes src/soldb/core/transaction_tracer.py` — redefinition warning gone