### PR TITLE
Cover remaining branches in parsers/abi.py and utils/exceptions.py

### DIFF
--- a/test/unit/test_utils_abi.py
+++ b/test/unit/test_utils_abi.py
@@ -13,11 +13,15 @@ from soldb.utils.logging import TRACE, ColoredFormatter, SoldbLogger, get_logger
 def test_abi_parsing_and_matching():
     assert match_abi_types(["uint256", "(address,uint256)", "uint256[]"], ["uint256", "tuple", "uint256[]"])
     assert not match_abi_types(["uint256"], ["uint256", "address"])
+    assert not match_abi_types(["address"], ["uint256"])
     assert match_single_type("(uint256)", "tuple")
     assert match_single_type("tuple(uint256)", "tuple")
     assert not match_single_type("address", "uint256")
+    assert match_single_type("uint256[]", "uint256[]")
+    assert not match_single_type("uint8[]", "uint256[]")
     assert parse_signature("transfer(address,uint256)") == ("transfer", ["address", "uint256"])
     assert parse_signature("foo((uint256,address),uint8[])") == ("foo", ["(uint256,address)", "uint8[]"])
+    assert parse_signature("noop()") == ("noop", [])
     assert parse_signature("not a signature") == ("", [])
 
     abi_input = {
@@ -61,9 +65,12 @@ def test_exception_types_and_formatting():
 
     assert exceptions.format_error(ValueError("plain"), json_mode=True)
     assert "plain" in exceptions.format_error(ValueError("plain"), json_mode=False)
+    assert "bad rpc" in exceptions.format_error(exceptions.RPCConnectionError("bad rpc"), json_mode=False)
     assert exceptions.format_error_json("msg", "Kind", extra=1)["extra"] == 1
     assert exceptions.format_exception_message(Exception({"message": "rpc message"})) == "rpc message"
+    assert exceptions.format_exception_message(Exception("plain string")) == "plain string"
     assert exceptions.format_exception_message(Exception(7)) == "7"
+    assert exceptions.format_exception_message(Exception()) == ""
     assert exceptions.ConnectionError is exceptions.RPCConnectionError
 
 


### PR DESCRIPTION
## Summary
Adds a handful of small assertions to the existing `test_utils_abi.py` to close coverage gaps in two pure-function modules.

After this PR:
- `src/soldb/parsers/abi.py` — **100% line + branch coverage** (was 92%)
- `src/soldb/utils/exceptions.py` — 100% line coverage (was missing 4 lines); branch coverage 96% (the remaining 5 missed branches are unreachable type-narrowing in the dataclass `to_dict` paths)

## What's covered

### `parsers/abi.py`
- `match_abi_types` — types of equal length but with one mismatched element (previously only the length-mismatch path was hit).
- `match_single_type` — array-of-X with differing base type (e.g. `uint8[]` vs `uint256[]`), both the equal-bases short-circuit and the recursive-with-different-bases path.
- `parse_signature` — signature with no args, e.g. `noop()`, exercising the empty-`current` branch in `split_args`.

### `utils/exceptions.py`
- `format_error(SoldbError, json_mode=False)` — the previously-untested text path for soldb errors.
- `format_exception_message` — `args[0]` is a plain string (returns it verbatim) and exception with no args at all (falls through to `str(e)`).

## Test plan
- [x] `pytest test/unit` — 247 passing, no regressions
- [x] `pytest test/unit/test_utils_abi.py --cov=soldb.parsers.abi --cov=soldb.utils.exceptions --cov-report=term-missing` — confirms 100% on `parsers/abi.py` and the targeted lines in `exceptions.py`