### PR TITLE
Remove unused imports from cli/contracts.py and cli/events.py

### DIFF
--- a/src/soldb/cli/contracts.py
+++ b/src/soldb/cli/contracts.py
@@ -5,18 +5,14 @@ This module handles listing all contracts involved in a transaction.
 """
 
 import sys
-import json
 from pathlib import Path
-from typing import Optional
 
 from soldb.core.transaction_tracer import TransactionTracer
 from soldb.parsers.ethdebug import MultiContractETHDebugParser, ETHDebugDirParser
 from soldb.utils.colors import error
-from soldb.utils.logging import logger
 from soldb.cli.common import (
     get_ethdebug_dirs,
     is_multi_contract_mode,
-    load_abi_files,
 )
 
 

--- a/src/soldb/cli/events.py
+++ b/src/soldb/cli/events.py
@@ -7,13 +7,11 @@ This module handles listing and decoding events from transaction logs.
 import sys
 import json
 from pathlib import Path
-from typing import Optional
 
 from soldb.core.transaction_tracer import TransactionTracer
 from soldb.parsers.ethdebug import MultiContractETHDebugParser, ETHDebugDirParser
 from soldb.utils.colors import error
 from soldb.utils.exceptions import format_error_json
-from soldb.utils.logging import logger
 from soldb.cli.common import (
     get_ethdebug_dirs,
     is_multi_contract_mode,


### PR DESCRIPTION
## Summary
Drops six imports that pyflakes flagged as unused in two CLI modules. Pure dead-code cleanup — no behavior change.

## Removed

**`src/soldb/cli/contracts.py`**
- `json` — no `json.` references
- `typing.Optional` — not used in any annotation
- `soldb.utils.logging.logger` — not used; the module prints directly
- `soldb.cli.common.load_abi_files` — not used

**`src/soldb/cli/events.py`**
- `typing.Optional` — not used in any annotation
- `soldb.utils.logging.logger` — not used; the module prints directly

## Safety
Greps confirm the only symbols imported from these two modules elsewhere in the codebase are `list_contracts_command` (from `cli/main.py`, `cli/__init__.py`) and `list_events_command` (same callers). None of the removed names are re-exported.

## Test plan
- [x] `pyflakes src/soldb/cli/contracts.py src/soldb/cli/events.py` — clean
- [x] `python -c "from soldb.cli.contracts import list_contracts_command; from soldb.cli.events import list_events_command"` — succeeds
- [x] `pytest test/unit` — 247 passing, no regressions