### PR TITLE
Cover error and cache branches in cross_env.bridge_client

### DIFF
--- a/test/unit/test_bridge_client.py
+++ b/test/unit/test_bridge_client.py
@@ -92,6 +92,128 @@ def test_bridge_client_error_paths(monkeypatch):
     assert CrossEnvBridgeClient().get_contract("0x0") is None
 
 
+def test_bridge_client_http_error_with_non_json_body(monkeypatch):
+    class NonJsonBody:
+        def read(self):
+            return b"<html>not json</html>"
+
+        def close(self):
+            pass
+
+    def http_error(req, timeout):
+        raise urllib.error.HTTPError(
+            req.full_url, 503, "service down", {}, NonJsonBody(),
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", http_error)
+    with pytest.raises(BridgeClientError, match="HTTP 503: service down"):
+        CrossEnvBridgeClient().health_check()
+
+
+def test_bridge_client_wraps_unexpected_exceptions(monkeypatch):
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda req, timeout: (_ for _ in ()).throw(RuntimeError("kaboom")),
+    )
+    with pytest.raises(BridgeClientError, match="Request failed: kaboom"):
+        CrossEnvBridgeClient().health_check()
+
+
+def test_bridge_client_get_trace_returns_none_on_error(monkeypatch):
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda req, timeout: (_ for _ in ()).throw(urllib.error.URLError("no host")),
+    )
+    assert CrossEnvBridgeClient().get_trace("missing") is None
+
+
+def test_stylus_integration_client_property_lazily_creates_client():
+    integration = StylusBridgeIntegration(bridge_url="http://example/")
+    assert integration._client is None
+    first = integration.client
+    assert isinstance(first, CrossEnvBridgeClient)
+    # Second access must return the same memoized instance.
+    assert integration.client is first
+
+
+def test_stylus_integration_connect_handles_client_exception(monkeypatch):
+    integration = StylusBridgeIntegration(enabled=True)
+
+    class BoomClient:
+        def is_available(self):
+            raise RuntimeError("network unreachable")
+
+    integration._client = BoomClient()
+    assert integration.connect() is False
+    assert integration.is_connected is False
+
+
+def test_stylus_integration_uses_cache_for_repeated_lookups():
+    integration = StylusBridgeIntegration(enabled=True)
+    integration._connected = True
+
+    calls = {"get": 0}
+
+    class CachingClient:
+        def get_contract(self, address):
+            calls["get"] += 1
+            return ContractInfo("0xabc", "stylus", "Cached")
+
+    integration._client = CachingClient()
+
+    assert integration.is_stylus_contract("0xABC") is True
+    assert integration.get_contract_info("0xabc").name == "Cached"
+    # Both calls hit the same normalized key, so the bridge is queried once.
+    assert calls["get"] == 1
+
+
+def test_stylus_integration_cached_none_short_circuits():
+    integration = StylusBridgeIntegration(enabled=True)
+    integration._connected = True
+    integration._contract_cache["0xabc"] = None
+    assert integration.is_stylus_contract("0xabc") is False
+    assert integration.get_contract_info("0xabc") is None
+
+
+def test_stylus_integration_swallows_bridge_errors():
+    integration = StylusBridgeIntegration(enabled=True)
+    integration._connected = True
+
+    class FailingClient:
+        def get_contract(self, address):
+            raise BridgeClientError("offline")
+
+        def request_stylus_trace(self, **kwargs):
+            raise BridgeClientError("offline")
+
+        def register_contract(self, contract):
+            raise BridgeClientError("offline")
+
+    integration._client = FailingClient()
+    assert integration.is_stylus_contract("0x1") is False
+    assert integration.get_contract_info("0x1") is None
+    assert integration.request_trace("0x1", "0x00") is None
+    assert integration.register_contract(ContractInfo("0x1", "evm", "E")) is False
+
+
+def test_stylus_integration_disabled_short_circuits_register_and_request():
+    integration = StylusBridgeIntegration(enabled=False)
+    assert integration.request_trace("0x1", "0x00") is None
+    assert integration.register_contract(ContractInfo("0x1", "evm", "E")) is False
+
+
+def test_stylus_integration_request_trace_returns_none_when_no_trace():
+    integration = StylusBridgeIntegration(enabled=True)
+    integration._connected = True
+
+    class TraceLessClient:
+        def request_stylus_trace(self, **kwargs):
+            return TraceResponse("r", "success", trace=None)
+
+    integration._client = TraceLessClient()
+    assert integration.request_trace("0x1", "0x00") is None
+
+
 def test_stylus_bridge_integration_cache_and_failures(monkeypatch):
     integration = StylusBridgeIntegration(enabled=False)
     assert not integration.connect()


### PR DESCRIPTION
## Summary
- Adds tests in `test_bridge_client.py` for previously uncovered branches: `_make_request` HTTP errors with non-JSON bodies and unexpected exceptions, `get_trace` swallowing errors, the lazy `client` property on `StylusBridgeIntegration`, `connect()` exception handling, contract-cache hit paths (positive and cached-None), `BridgeClientError` swallowing in `is_stylus_contract` / `get_contract_info` / `request_trace` / `register_contract`, the disabled-state short-circuit, and `request_trace` returning None when the response carries no trace.
- No production code changes; tests only.

## Test plan
- [x] `pytest test/unit/test_bridge_client.py` — 13 passed (3 existing + 10 new)
- [x] `pytest test/unit` — 264 passed (no regressions)