### PR TITLE
Update CONTRIBUTING.md to reflect Rust-based setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,18 @@
 ```bash
 git clone https://github.com/walnuthq/soldb.git
 cd soldb
-pip install -e ".[dev]"
+cargo build --workspace --all-targets
 ```
+
+See [README.md](./README.md#development) for the full development setup, including running the lit-based end-to-end tests.
 
 ## Submitting changes
 
 1. Fork the repo and create a branch off `main`
 2. Make your changes
-3. Open a pull request — describe what you changed and why
+3. Run `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings`
+4. Run `cargo test --workspace --all-targets`
+5. Open a pull request — describe what you changed and why
 
 ## Reporting bugs
 


### PR DESCRIPTION
## Summary
- The setup section still referenced `pip install -e \".[dev]\"` from when the project was Python; the codebase has since been ported to Rust (see #113).
- Replace the Python instructions with the equivalent Cargo commands and link to the Development section in the README for fuller details.
- Add `cargo fmt` / `clippy` / `cargo test` to the submit checklist to match the gates enforced in CI.

## Test plan
- [x] No code changes; verified the README anchor (`#development`) matches the existing heading.