### PR TITLE
Switch Makefile clean target to Rust artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ test-deploy:
 	./test/test-setup.sh --deploy-test
 
 clean:
-	rm -rf build dist *.egg-info
-	rm -rf __pycache__ */__pycache__ */*/__pycache__
-	find . -name "*.pyc" -delete
+	cargo clean
+	rm -rf build dist out test/Output
 	find . -name ".DS_Store" -delete


### PR DESCRIPTION
## Summary
- `make clean` still only deleted Python build artifacts (`build dist *.egg-info`, `__pycache__`, `*.pyc`) from the pre-Rust days, so the meaningful output of `cargo build` was never cleaned.
- Replace those rules with `cargo clean` plus removal of `build`, `dist`, `out`, and `test/Output` (the directories actually produced today).
- Keep the `.DS_Store` sweep so macOS clutter still goes away.

## Test plan
- [x] `make -n clean` previews the new commands.
- [x] No other Make targets reference the removed Python paths.