### PR TITLE
Drop Python-only entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,11 @@
 cache/
 dist/
 target/
-.coverage
-.coverage.*
-coverage.xml
 rust-coverage.xml
-htmlcov/
 examples/debug/
 examples/debug*/
 examples/out*/
 out/
-__pycache__/
-*.txt
-src/soldb.egg-info/PKG-INFO
 
 examples/test_debug/
 test/Output/


### PR DESCRIPTION
## Summary
- After the Rust port, none of these patterns describe anything the build produces anymore:
  - `.coverage` / `.coverage.*` / `coverage.xml` / `htmlcov/` — `coverage.py` outputs
  - `__pycache__/` — CPython bytecode caches
  - `*.txt` — only kept to hide `src/soldb.egg-info/*.txt`, but the unbounded glob silently hid every `.txt` in the tree (including potential test fixtures or docs)
  - `src/soldb.egg-info/PKG-INFO` — setuptools metadata
- Cargo's outputs (`target/`, `rust-coverage.xml`) and the lit harness outputs stay.

## Test plan
- [x] `git status` in a clean checkout shows no newly-tracked files surfacing from the removed rules.
- [x] No tracked file currently matches the removed patterns (`git ls-files | grep -E '\\.txt$|PKG-INFO|__pycache__|htmlcov|\\.coverage|coverage\\.xml'` is empty).