### PR TITLE
Update bug report template for Rust-based SolDB

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,7 @@ labels: bug
 
 
 **Environment**
-- SolDB version:
-- Python version:
+- SolDB version (`soldb --version`):
+- Rust toolchain (`rustc --version`):
+- `solc` version:
 - OS:


### PR DESCRIPTION
## Summary
- The bug report template still asked reporters for their **Python version**, which is no longer relevant after the Rust port (the SolDB binary is a Rust executable).
- Replace it with the fields actually needed to reproduce issues today: SolDB version, Rust toolchain, and `solc` version. Each one shows the command that prints the value, so reporters don't have to guess.

## Test plan
- [x] Visual review of the new template in the `.github/ISSUE_TEMPLATE/bug_report.md` raw file.
- [x] No grep hits left for "Python" in user-facing surfaces (`README.md`, `CONTRIBUTING.md`, issue templates, Makefile).