### PR TITLE
Add feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement for SolDB
+labels: enhancement
+---
+
+**What problem are you trying to solve?**
+
+
+**Proposed solution**
+
+
+**Alternatives considered**
+
+
+**Additional context**


### PR DESCRIPTION
## Summary
- `.github/ISSUE_TEMPLATE/` only contained `bug_report.md`, so opening a feature request landed on a blank issue body and contributors had to guess what info to include.
- Adds `feature_request.md` with the standard prompts (problem, proposed solution, alternatives, additional context) and an `enhancement` label, mirroring the existing bug template style.

## Test plan
- [x] File is valid front-matter Markdown (same shape as `bug_report.md`).
- [x] GitHub will surface both templates side-by-side on the new-issue picker.