### PR TITLE
Drop Python virtualenv soldb fallbacks from test/run-tests.sh

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -321,16 +321,6 @@ elif command -v soldb &> /dev/null; then
     SOLDB_CMD="soldb"
     SOLDB_TYPE="path"
     echo -e "${GREEN}Using PATH soldb${NC}"
-elif [ -f "${PROJECT_DIR}/.venv/bin/soldb" ]; then
-    # Fall back to local virtual environment
-    SOLDB_CMD="${PROJECT_DIR}/.venv/bin/soldb"
-    SOLDB_TYPE="venv"
-    echo -e "${GREEN}Using .venv soldb${NC}"
-elif [ -f "${PROJECT_DIR}/MyEnv/bin/soldb" ]; then
-    # Fall back to virtual environment
-    SOLDB_CMD="${PROJECT_DIR}/MyEnv/bin/soldb"
-    SOLDB_TYPE="venv"
-    echo -e "${GREEN}Using venv soldb${NC}"
 else
     echo -e "${RED}Error: soldb not found${NC}"
     echo "Build it with: cargo build --bin soldb"
@@ -355,10 +345,6 @@ if "${SOLDB_CMD}":
     config.soldb = "${SOLDB_CMD}"
 elif shutil.which('soldb'):
     config.soldb = shutil.which('soldb')
-elif os.path.exists(os.path.join(project_dir, '.venv', 'bin', 'soldb')):
-    config.soldb = os.path.join(project_dir, '.venv', 'bin', 'soldb')
-elif os.path.exists(os.path.join(project_dir, 'MyEnv', 'bin', 'soldb')):
-    config.soldb = os.path.join(project_dir, 'MyEnv', 'bin', 'soldb')
 else:
     config.soldb = "${SOLDB_CMD}"
 config.rpc_url = "${RPC_URL}"


### PR DESCRIPTION
## Summary
- After the Rust port, `soldb` is a Cargo-built binary; the `.venv/bin/soldb` and `MyEnv/bin/soldb` fallbacks can never succeed because no Python `soldb` package ships anymore.
- Remove the dead branches from both the shell binary search and the embedded `lit.site.cfg.py` heredoc so the chain ends at: `SOLDB_BIN` override → `target/debug` → `target/release` → `PATH` → error.
- Also drops the last two `SOLDB_TYPE=venv` paths; nothing else references that label.

## Test plan
- [x] `bash -n test/run-tests.sh` — syntax OK.
- [x] `grep -n venv\|MyEnv` against the script — no remaining references.
- [x] The lookup order still covers every realistic case (override env var, in-tree debug/release build, system PATH).