### PR TITLE
Drop Python virtualenv soldb branches from lit.cfg.py

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -33,13 +33,6 @@ if hasattr(config, 'soldb') and config.soldb:
     soldb_path = config.soldb
 else:
     soldb_path = shutil.which('soldb')
-    if not soldb_path and hasattr(config, 'soldb_dir'):
-        # Try to find it in the virtual environment
-        for venv_name in ('.venv', 'MyEnv'):
-            venv_path = os.path.join(config.soldb_dir, venv_name, 'bin', 'soldb')
-            if os.path.exists(venv_path):
-                soldb_path = venv_path
-                break
 
 if soldb_path:
     config.substitutions.append(('%soldb', soldb_path))
@@ -156,10 +149,4 @@ for env_var in ('COVERAGE_FILE', 'COVERAGE_RCFILE'):
     if env_var in os.environ:
         config.environment[env_var] = os.environ[env_var]
 
-if not hasattr(config, 'soldb') or not config.soldb:
-    config.environment['PYTHONPATH'] = os.pathsep.join(sys.path)
-elif 'venv' in config.soldb or 'MyEnv' in config.soldb:
-    # Using venv - don't set PYTHONPATH, let venv handle it
-    pass
-else:
-    config.environment['PYTHONPATH'] = os.pathsep.join(sys.path)
+config.environment['PYTHONPATH'] = os.pathsep.join(sys.path)


### PR DESCRIPTION
## Summary
Two leftovers from the pre-Rust days in `test/lit.cfg.py`:

- The `soldb` lookup walked `.venv/` and `MyEnv/` for a Python-installed `soldb` binary. That binary no longer exists, so the loop is dead.
- The `PYTHONPATH` setup branched on whether `config.soldb` contained `venv`/`MyEnv` to avoid setting PYTHONPATH for the Python package. With the venv path gone, the `if/elif/else` collapses to one unconditional assignment.

Net: `lit.cfg.py` now matches reality (soldb is a Rust binary).

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('test/lit.cfg.py').read())"` parses clean.
- [x] No other code path inspects `config.soldb` for "venv"/"MyEnv" substrings.