### PR TITLE
Add help text to soldb's --version flag

### DIFF
--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -93,7 +93,12 @@ fn separator(width: usize) -> String {
     disable_version_flag = true
 )]
 struct Cli {
-    #[arg(short = 'v', long = "version", action = clap::ArgAction::Version)]
+    #[arg(
+        short = 'v',
+        long = "version",
+        action = clap::ArgAction::Version,
+        help = "Print version"
+    )]
     _version: Option<bool>,
     #[command(subcommand)]
     command: Command,


### PR DESCRIPTION
## Summary
- The top-level `Cli` struct overrides clap's default `--version` action so it can use the workspace version, but didn't supply a `help` string.
- `soldb --help` therefore rendered an unexplained `-v, --version` row next to the populated `-h, --help` row.
- Add an explicit `help = "Print version"` so both option rows match.

Before:
```
Options:
  -v, --version
  -h, --help     Print help
```

After:
```
Options:
  -v, --version  Print version
  -h, --help     Print help
```

## Test plan
- [x] `cargo build --bin soldb` — clean.
- [x] `cargo clippy --bin soldb` — clean.
- [x] `soldb --help` shows the new help text.
- [x] `soldb --version` still prints `soldb 0.1.0`.