### PR TITLE
Add -r short flag to 'soldb simulate --rpc-url'

### DIFF
--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -263,6 +263,7 @@ struct SimulateArgs {
     #[arg(
         long = "rpc-url",
         alias = "rpc",
+        short = 'r',
         default_value = "http://localhost:8545"
     )]
     rpc_url: String,


### PR DESCRIPTION
## Summary
- `soldb trace`, `list-contracts`, and `list-events` all accept `-r` as the short form of `--rpc-url` (or `--rpc` on `trace`).
- `simulate` was the odd one out: it already declared `alias = "rpc"` for the long form but had no short flag, so `soldb simulate -r URL …` failed even though the parallel commands accept it.
- Adding `short = 'r'` fills the gap.

## Test plan
- [x] `cargo build --bin soldb` — clean.
- [x] `cargo clippy --bin soldb` — clean.
- [x] `cargo test --bin soldb` — 10 passed.
- [x] `soldb help simulate` now shows `-r, --rpc-url <RPC_URL>`.
- [x] Purely additive: `--rpc-url`, `--rpc`, and `-r` all parse to the same field; no other simulate arg used `-r` so no clap conflict.