### PR TITLE
Fix REPL prompt format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ soldb trace <tx_hash> --ethdebug-dir <contract_address>:<contract_name>:./out --
 
 Inside REPL:
 ```
-(soldb) break TestContract.sol:42
-(soldb) next
-(soldb) print balance
+soldb> break TestContract.sol:42
+soldb> next
+soldb> print balance
 ```
 
 ---
@@ -116,9 +116,9 @@ soldb simulate <contract_address> "increment(uint256)" 5     --from <sender_addr
 
 Inside REPL:
 ```
-(soldb) break TestContract.sol:38
-(soldb) step
-(soldb) vars
+soldb> break TestContract.sol:38
+soldb> step
+soldb> vars
 ```
 
 ---


### PR DESCRIPTION
## Summary
- The README's interactive sections used `(soldb)` as the prompt prefix, but the actual REPL prints `soldb> ` (`crates/soldb-cli/src/main.rs:841`).
- The new `docs/commands.md` (added in #137) already uses `soldb>` everywhere, so the README was the odd one out.
- Anyone copy-pasting from the README would type a stray `(soldb)` before their command. Switch the two REPL snippets to the real prompt so the docs match the binary.

Note: `print balance` and `vars` are not implemented REPL commands today (see `docs/commands.md` for the supported set). Updating the example content is a separate decision and is left for follow-up — this PR only touches the prompt prefix.

## Test plan
- [x] `grep -n '(soldb)' README.md` — no remaining occurrences.
- [x] Diff is pure prefix swap; no command or contract reference changed.