### PR TITLE
List real REPL commands in README Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Inside REPL:
 - ETHDebug-first source debugging built around compiler-generated `solc --debug-info ethdebug` metadata
 - Full transaction traces with internal calls & decoded parameters
 - Transaction simulation with arbitrary calldata (including structs & tuples)
-- Interactive LLDB-like REPL (`step`, `break`, `print`, etc.) – works for both transactions and simulations
+- Interactive LLDB-like REPL (`step`, `next`, `break`, `continue`, etc.) – works for both transactions and simulations
 - HTTP/HTTPS JSON-RPC transport with debug-RPC tracing and normal-RPC replay for local Anvil transactions
 - Interop-ready tracing for Ethereum environments that combine EVM contracts with other VMs
 


### PR DESCRIPTION
## Summary
- The Features bullet advertised the REPL as `step`, `break`, `print`, etc., but `print` is not an implemented command.
- `docs/commands.md` (added in #137) is the authoritative list of supported commands: `next`, `nexti`, `step`, `continue`, `goto`, `break`, `clear`, `info`, `mode`, `help`, `quit`.
- Replace `print` with commands that exist today (`step`, `next`, `break`, `continue`) so the feature list matches the binary's behavior.

## Test plan
- [x] `grep -n print README.md` confirms no `print` REPL command reference remains.
- [x] Each replacement command is documented in `docs/commands.md`.