### PR TITLE
Link to docs/commands.md from the README REPL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Inside REPL:
 (soldb) print balance
 ```
 
+See [docs/commands.md](docs/commands.md) for the full list of REPL commands.
+
 ---
 
 ## Example: Simulating a Contract Call


### PR DESCRIPTION
## Summary
- `docs/commands.md` (added in #137) is the authoritative reference for the interactive REPL command set, but nothing in the repo linked to it (`grep -rn commands.md` returned no hits).
- Add a one-line pointer below the first "Inside REPL:" snippet so anyone reading the README's interactive examples can find the full command list without grepping `docs/`.

## Test plan
- [x] Linked file exists (`docs/commands.md`).
- [x] Diff is one additive line; no surrounding content moved.