### PR TITLE
ci: cache cargo registry and target dir with Swatinem/rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           rustup toolchain install stable --profile minimal --component clippy,rustfmt
           rustup default stable
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -78,6 +80,8 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Build Rust binaries
         run: cargo build --bin soldb --bin soldb-dap-server
 
@@ -120,6 +124,8 @@ jobs:
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install Rust coverage tool
         run: cargo install cargo-llvm-cov --locked


### PR DESCRIPTION
## Summary
All three CI jobs (`rust`, `lit`, `coverage`) currently rebuild every dependency from scratch on every run, which dominates CI time. The `coverage` job also recompiles `cargo-llvm-cov` itself every time.

Add `Swatinem/rust-cache@v2` right after each Rust toolchain install so the cargo registry, git index, and `target/` directory are restored from a per-job cache.

The action keys the cache off `Cargo.lock` + toolchain by default, so:
- cache hits skip the dependency compile entirely
- `Cargo.lock` or toolchain changes invalidate cleanly
- per-job key isolation means the `rust` / `lit` / `coverage` jobs each get a cache layout that matches their build profile

## Test plan
- [x] Drop-in change: no scripts modified, no flags changed.
- [x] Cold-cache runs (this PR and any others targeting `main` before a cache exists) behave the same as before; subsequent runs benefit from cached deps.
- [x] Each job installs the toolchain before `rust-cache` runs, which is the action's required ordering.