### PR TITLE
ci: install cargo-llvm-cov as a prebuilt binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,9 @@ jobs:
           rustup default stable
 
       - name: Install Rust coverage tool
-        run: cargo install cargo-llvm-cov --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
 
       - name: Run Rust coverage
         run: cargo llvm-cov --workspace --all-targets --cobertura --output-path rust-coverage.xml --fail-under-lines 80


### PR DESCRIPTION
## Summary
- The `coverage` job currently runs `cargo install cargo-llvm-cov --locked`, which compiles the tool from source on every run (typically several minutes).
- `taiki-e/install-action@v2` downloads the matching prebuilt binary directly from the `cargo-llvm-cov` GitHub releases — same tool, no compile.
- Only the install step is replaced; `cargo llvm-cov --workspace …` runs unchanged afterwards.

This is independent of #142 (rust-cache); they layer cleanly — `rust-cache` won't help the cold first run, and `taiki-e/install-action` keeps source-compilation out of the loop entirely.

## Test plan
- [x] No change to the `cargo llvm-cov` invocation or its flags.
- [x] `taiki-e/install-action@v2` is a widely-used standard action and ships official `cargo-llvm-cov` binaries.