### PR TITLE
ci: cancel superseded PR runs via concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   FOUNDRY_VERSION: v1.0.0
 


### PR DESCRIPTION
## Summary
Pushing a new commit to an open PR currently starts a fresh CI run while the previous one keeps using runner minutes — only the latest result is interesting, but we pay for both.

Add a `concurrency` block that groups runs by workflow + ref so a new push on the same branch cancels the older in-flight run:

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

The guard on `cancel-in-progress` means **main** builds always finish — useful for keeping the README badge accurate and for jobs that publish artifacts (the `coverage` job uploads `rust-coverage.xml`).

## Test plan
- [x] Standard GitHub Actions pattern; the `${{ … }}` expression returns a boolean and is supported in the `cancel-in-progress` field.
- [x] No change to job definitions or test commands.