### PR TITLE
test: fix broken deploy-test path in test-setup.sh

### DIFF
--- a/test/test-setup.sh
+++ b/test/test-setup.sh
@@ -79,13 +79,13 @@ echo "  DEBUG_DIR=$DEBUG_DIR"
 if [ "$1" = "--deploy-test" ] || [ "$1" = "-d" ]; then
     echo
     echo -e "${BLUE}Deploying TestContract for tests...${NC}"
-    if [ -x "$SCRIPT_DIR/test/deploy-test-contract.sh" ]; then
+    if [ -x "$SCRIPT_DIR/deploy-test-contract.sh" ]; then
         # Ensure SOLC_PATH is properly set
         if [ -z "$SOLC_PATH" ] && command -v solc &> /dev/null; then
             SOLC_PATH=$(which solc)
         fi
         SOLC_PATH="$SOLC_PATH" RPC_URL="$RPC_URL" PRIVATE_KEY="$PRIVATE_KEY" \
-            "$SCRIPT_DIR/test/deploy-test-contract.sh"
+            "$SCRIPT_DIR/deploy-test-contract.sh"
         if [ $? -eq 0 ]; then
             echo -e "${GREEN}✓ Test contract deployed successfully${NC}"
         else


### PR DESCRIPTION
## Summary
`$SCRIPT_DIR` in `test/test-setup.sh` already resolves to the `test/` directory (the script lives there), but the `--deploy-test` branch joined it with `test/` again — so `$SCRIPT_DIR/test/deploy-test-contract.sh` resolved to `<repo>/test/test/deploy-test-contract.sh`, which doesn't exist.

The `-x` guard silently masked the bug: `./test/test-setup.sh --deploy-test` (and `make test-deploy`, which delegates to it via the Makefile) always fell through to the "Test deployment script not found or not executable" branch and exited 0 without doing anything.

Drop the extra `test/` segment so the script actually invokes `test/deploy-test-contract.sh`.

## Test plan
- [x] `ls test/deploy-test-contract.sh` exists; `ls test/test/deploy-test-contract.sh` did not.
- [x] `bash -n test/test-setup.sh` — syntax OK.
- [x] Path now matches every other reference in `test/run-tests.sh` (which already uses `${SCRIPT_DIR}/deploy-test-contract.sh`).