### PR TITLE
docs: align REPL examples with supported commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ soldb trace <tx_hash> --ethdebug-dir <contract_address>:<contract_name>:./out --
 
 Inside REPL:
 ```
-(soldb) break TestContract.sol:42
-(soldb) next
-(soldb) print balance
+soldb> break TestContract.sol:42
+soldb> next
+soldb> info resources
 ```
 
 ---
@@ -116,9 +116,9 @@ soldb simulate <contract_address> "increment(uint256)" 5     --from <sender_addr
 
 Inside REPL:
 ```
-(soldb) break TestContract.sol:38
-(soldb) step
-(soldb) vars
+soldb> break TestContract.sol:38
+soldb> step
+soldb> mode asm
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Update README interactive examples to use the actual `soldb>` prompt.
- Replace unsupported `print`/`vars` examples with currently supported REPL commands.
- Keep source-line breakpoint examples, which are supported by the current REPL.

Fixes #129.

## Tests
- `cargo test -p soldb-repl parses_repl_commands_and_aliases`