### PR TITLE
fix: preserve observed storage diff state

### DIFF
--- a/crates/soldb-rpc/src/lib.rs
+++ b/crates/soldb-rpc/src/lib.rs
@@ -578,7 +578,7 @@ impl DebugTraceResult {
                 let step = log
                     .clone()
                     .into_trace_step_with_previous_storage(&previous_storage);
-                previous_storage = log.storage;
+                previous_storage.extend(log.storage);
                 step
             })
             .collect()
@@ -2310,6 +2310,38 @@ mod tests {
         );
         assert_eq!(steps[1].gas_cost, 0);
         assert!(steps[1].snapshot.storage_diff.is_empty());
+    }
+
+    #[test]
+    fn storage_diff_uses_prior_observed_slot_value() {
+        let result: DebugTraceResult = serde_json::from_value(json!({
+            "returnValue": "",
+            "structLogs": [
+                {
+                    "pc": 0,
+                    "op": "SSTORE",
+                    "gas": 100,
+                    "gasCost": 3,
+                    "depth": 0,
+                    "storage": {"0x04": "0x32"}
+                },
+                {"pc": 1, "op": "PUSH1", "gas": 97, "depth": 0},
+                {
+                    "pc": 2,
+                    "op": "SSTORE",
+                    "gas": 96,
+                    "gasCost": 3,
+                    "depth": 0,
+                    "storage": {"0x04": "0x4b"}
+                }
+            ]
+        }))
+        .expect("debug trace");
+
+        let steps = result.steps();
+        let second_write = &steps[2].snapshot.storage_diff["0x04"];
+        assert_eq!(second_write.before.as_deref(), Some("0x32"));
+        assert_eq!(second_write.after.as_deref(), Some("0x4b"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Preserve previously observed storage slot values while converting debug RPC struct logs into trace steps.
- Avoid dropping the observed slot map on non-storage steps.
- Add regression coverage for a repeated write to the same slot separated by a non-storage step, so the second `storage_diff.before` reports the first write's `after` value.

Partially addresses #130 by fixing prior observed in-trace slot values. Reading parent-block storage for the first write to an already-initialized slot likely needs a separate backend/RPC state lookup.

## Tests
- `cargo test -p soldb-rpc storage_diff_uses_prior_observed_slot_value`