### PR TITLE
Support solc versions that dropped --ethdebug/--ethdebug-runtime

### DIFF
--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -1515,7 +1515,12 @@ struct TraceSourceIndex {
 
 impl TraceSourceIndex {
     fn load(spec: &ResolvedContractSpec) -> SoldbResult<Self> {
-        let metadata_path = spec.debug_dir.join("ethdebug.json");
+        let metadata_path = find_ethdebug_metadata(&spec.debug_dir).ok_or_else(|| {
+            soldb_core::SoldbError::Message(format!(
+                "No ETHDebug metadata file (ethdebug.json or ethdebug_resources.json) found in {}",
+                spec.debug_dir.display()
+            ))
+        })?;
         let runtime_path = find_runtime_ethdebug(&spec.debug_dir, &spec.name).ok_or_else(|| {
             soldb_core::SoldbError::Message(format!(
                 "No ETHDebug runtime file found in {}",
@@ -2219,6 +2224,17 @@ fn format_raw_stack(stack: &[String]) -> String {
         .map(|(index, value)| format!("[{index}] {}", normalize_stack_word(value)))
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn find_ethdebug_metadata(root: &Path) -> Option<PathBuf> {
+    // Modern solc (>= ~0.8.32) renamed the global ETHDebug metadata file from
+    // `ethdebug.json` to `ethdebug_resources.json`; accept either.
+    [
+        root.join("ethdebug.json"),
+        root.join("ethdebug_resources.json"),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
 }
 
 fn find_runtime_ethdebug(root: &Path, contract_name: &str) -> Option<PathBuf> {

--- a/crates/soldb-compiler/src/lib.rs
+++ b/crates/soldb-compiler/src/lib.rs
@@ -88,12 +88,38 @@ impl CompilerConfig {
     ) -> SoldbResult<CompilationResult> {
         let output_dir = output_dir.unwrap_or(&self.debug_output_dir);
         self.ensure_directories()?;
-        run_solc(
+        // solc >= ~0.8.32 dropped the `--ethdebug`/`--ethdebug-runtime` flags in favor of
+        // `--ethdebug-program`/`--ethdebug-program-runtime` (gated behind `--experimental`).
+        // Try the configured (legacy) flags first for compatibility with older/pinned solc
+        // installs, and fall back to the modern flag names only if solc specifically rejects
+        // the legacy ones - this keeps a single code path working across solc versions without
+        // needing to parse and hardcode a version cutoff.
+        match run_solc(
             &self.solc_path,
             &self.ethdebug_flags,
             contract_file.as_ref(),
             output_dir,
-        )
+        ) {
+            Ok(result) => Ok(result),
+            Err(SoldbError::Message(legacy_error))
+                if is_unrecognised_ethdebug_option(&legacy_error) =>
+            {
+                let modern_flags = modern_ethdebug_flags(&self.ethdebug_flags);
+                run_solc(
+                    &self.solc_path,
+                    &modern_flags,
+                    contract_file.as_ref(),
+                    output_dir,
+                )
+                .map_err(|modern_error| {
+                    SoldbError::Message(format!(
+                        "Compilation failed with legacy ETHDebug flags ({legacy_error}); \
+                             retry with modern ETHDebug flags also failed ({modern_error})"
+                    ))
+                })
+            }
+            Err(other) => Err(other),
+        }
     }
 
     pub fn compile_for_production(
@@ -387,12 +413,47 @@ fn run_solc(
     })
 }
 
+/// solc's replacement names for the ETHDebug flags it dropped (see
+/// `CompilerConfig::compile_with_ethdebug`). Kept as an explicit table rather than a
+/// string-pattern rewrite so it's obvious exactly which flags are affected.
+const MODERN_ETHDEBUG_REPLACEMENTS: &[(&str, &str)] = &[
+    ("--ethdebug", "--ethdebug-program"),
+    ("--ethdebug-runtime", "--ethdebug-program-runtime"),
+];
+
+fn modern_ethdebug_flags(flags: &[String]) -> Vec<String> {
+    let mut modern = Vec::with_capacity(flags.len() + 2);
+    modern.push("--experimental".to_owned());
+    for flag in flags {
+        let replacement = MODERN_ETHDEBUG_REPLACEMENTS
+            .iter()
+            .find(|(old, _)| *old == flag)
+            .map_or_else(|| flag.clone(), |(_, new)| (*new).to_owned());
+        modern.push(replacement);
+    }
+    // The old single `--ethdebug` flag also produced the global resources file
+    // (`ethdebug.json`); the modern API splits that out into its own opt-in flag.
+    if flags.iter().any(|flag| flag == "--ethdebug") {
+        modern.push("--ethdebug-resources".to_owned());
+    }
+    modern
+}
+
+fn is_unrecognised_ethdebug_option(error_message: &str) -> bool {
+    error_message.contains("unrecognised option") && error_message.contains("--ethdebug")
+}
+
 fn discover_output_files(output_dir: &Path) -> SoldbResult<CompilerOutputFiles> {
+    // Modern solc renames the global resources file from `ethdebug.json` to
+    // `ethdebug_resources.json`; accept either.
+    let global_ethdebug = [
+        output_dir.join("ethdebug.json"),
+        output_dir.join("ethdebug_resources.json"),
+    ]
+    .into_iter()
+    .find(|path| path.exists());
     let mut files = CompilerOutputFiles {
-        ethdebug: output_dir
-            .join("ethdebug.json")
-            .exists()
-            .then(|| output_dir.join("ethdebug.json")),
+        ethdebug: global_ethdebug,
         contracts: BTreeMap::new(),
     };
 

--- a/test/deploy-contract.sh
+++ b/test/deploy-contract.sh
@@ -165,6 +165,31 @@ echo -e "${BLUE}Running: $SOLC_PATH ${COMPILE_FLAGS[*]} $CONTRACT_FILE${NC}"
 
 # Check for errors
 COMPILE_EXIT_CODE=${PIPESTATUS[0]}
+
+# solc >= ~0.8.32 dropped the `--ethdebug`/`--ethdebug-runtime` flags in favor of
+# `--ethdebug-program`/`--ethdebug-program-runtime` (gated behind `--experimental`), and
+# moved the global resources output behind its own `--ethdebug-resources` flag. Retry with
+# the modern flag names if solc specifically rejected the legacy ones, rather than hardcoding
+# a version cutoff that will inevitably drift out of date again.
+if [ "$USE_ETHDEBUG" = true ] && [ $COMPILE_EXIT_CODE -ne 0 ] && grep -q "unrecognised option" "$DEBUG_DIR/compile.log" && grep -q -- "--ethdebug" "$DEBUG_DIR/compile.log"; then
+    echo -e "${YELLOW}Legacy ETHDebug flags not recognised by this solc; retrying with modern flag names...${NC}"
+    COMPILE_FLAGS=(
+        --via-ir
+        --debug-info ethdebug
+        --experimental
+        --ethdebug-program
+        --ethdebug-program-runtime
+        --ethdebug-resources
+        --bin
+        --abi
+        --overwrite
+        -o "$DEBUG_DIR"
+    )
+    echo -e "${BLUE}Running: $SOLC_PATH ${COMPILE_FLAGS[*]} $CONTRACT_FILE${NC}"
+    "$SOLC_PATH" "${COMPILE_FLAGS[@]}" "$CONTRACT_FILE" 2>&1 | tee "$DEBUG_DIR/compile.log"
+    COMPILE_EXIT_CODE=${PIPESTATUS[0]}
+fi
+
 if [ $COMPILE_EXIT_CODE -ne 0 ]; then
     if [ "$USE_ETHDEBUG" = true ]; then
         echo -e "${RED}ETHDebug compilation failed with exit code $COMPILE_EXIT_CODE${NC}"
@@ -178,9 +203,11 @@ fi
 # Verify output files were created
 if [ "$USE_ETHDEBUG" = true ]; then
     echo -e "\n${BLUE}Verifying ETHDebug output...${NC}"
-    
-    if [ ! -f "$DEBUG_DIR/ethdebug.json" ]; then
-        echo -e "${YELLOW}Warning: Main ethdebug.json file not found${NC}"
+
+    # Modern solc renames the global resources file from `ethdebug.json` to
+    # `ethdebug_resources.json`; accept either.
+    if [ ! -f "$DEBUG_DIR/ethdebug.json" ] && [ ! -f "$DEBUG_DIR/ethdebug_resources.json" ]; then
+        echo -e "${YELLOW}Warning: Main ethdebug.json/ethdebug_resources.json file not found${NC}"
     else
         echo -e "${GREEN}✓ Found ethdebug.json${NC}"
     fi


### PR DESCRIPTION
## Problem

solc >= ~0.8.32 removed the experimental `--ethdebug`/`--ethdebug-runtime` CLI flags in favor of the more granular `--ethdebug-program` / `--ethdebug-program-runtime` / `--ethdebug-resources`, gated behind a new `--experimental` flag. The global metadata file was also renamed (`ethdebug.json` → `ethdebug_resources.json`).

soldb's compile step (`crates/soldb-compiler`) hardcoded the old flags, and its own loader for `--ethdebug-dir` (`TraceSourceIndex::load` in `crates/soldb-cli`) hardcoded the old filename — so both silently broke against any solc where the legacy flags/filename no longer exist, which by now includes plain "latest".

## Fix

- **`soldb-compiler`**: try the configured (legacy) flags first, for compatibility with older/pinned solc installs, and only retry with the modern flag names if solc specifically rejects the legacy ones with `unrecognised option`. This avoids hardcoding a version-number cutoff that would need updating again as solc keeps evolving.
- **`soldb-cli`**: `TraceSourceIndex::load` (used by `trace`/`simulate --ethdebug-dir`) and `discover_output_files` now accept either `ethdebug.json` or `ethdebug_resources.json` as the global metadata file.
- **`test/deploy-contract.sh`**: mirrors the same retry so the LIT test suite and manual deploys work against current solc too.

Per-contract instruction files (`<Contract>_ethdebug.json` / `_ethdebug-runtime.json`) are unaffected — their schema is byte-identical between old and new solc; only the CLI flags and the global resources filename changed.

## Testing

Verified end-to-end (compile → deploy → trace/simulate with correct source-mapped output, e.g. `increment at Counter.sol:7`) against both:
- solc 0.8.31 (legacy flags)
- solc 0.8.36 / Homebrew latest (modern flags only)

- Full workspace test suite: 141/141 passing
- LIT suite: 34/35 applicable passing (6 correctly unsupported: Sepolia-key-gated + stylus-bridge), no regressions. The one failure (`replay-update-balance.test`) is a pre-existing, unrelated `debug-rpc` vs `replay` memory-snapshot formatting bug, unaffected by this change.
- `cargo clippy` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)