### PR TITLE
Support solc versions that dropped --ethdebug/--ethdebug-runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,23 @@ jobs:
         run: cargo test --workspace --all-targets
 
   lit:
-    name: lit
+    name: lit (solc ${{ matrix.solc.version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # ETHDebug artifacts are requested through different solc CLI flags depending on the
+        # compiler version, so cover both paths. See CompilerConfig::compile_with_ethdebug.
+        solc:
+          # Legacy flags: --ethdebug / --ethdebug-runtime, global file `ethdebug.json`.
+          - version: "0.8.31"
+            binary: solc-linux-amd64-v0.8.31+commit.fd3a2265
+            sha256: aac9cd0116e9ae0cd3d8f64a8641381845dc9f12e2a52653de36fb619323e557
+          # Modern flags: --experimental --ethdebug-program / --ethdebug-program-runtime /
+          # --ethdebug-resources, global file `ethdebug_resources.json`.
+          - version: "0.8.36"
+            binary: solc-linux-amd64-v0.8.36+commit.8a079791
+            sha256: c8d35afdddc3cd2743ee88b8f25e0fecd16e2bdd5f2120f37e52cd9cc45ae0e6
     steps:
       - uses: actions/checkout@v4
 
@@ -55,23 +70,31 @@ jobs:
         run: python -m pip install lit
 
       - name: Install Solidity compilers
+        env:
+          ETHDEBUG_SOLC_VERSION: ${{ matrix.solc.version }}
+          ETHDEBUG_SOLC_BINARY: ${{ matrix.solc.binary }}
+          ETHDEBUG_SOLC_SHA256: ${{ matrix.solc.sha256 }}
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.local/bin"
 
+          # ETHDebug compiler under test (matrixed).
           curl -fsSL \
-            -o "$HOME/.local/bin/solc-0.8.31" \
-            https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.31+commit.fd3a2265
-          echo "aac9cd0116e9ae0cd3d8f64a8641381845dc9f12e2a52653de36fb619323e557  $HOME/.local/bin/solc-0.8.31" | sha256sum -c -
+            -o "$HOME/.local/bin/solc-$ETHDEBUG_SOLC_VERSION" \
+            "https://binaries.soliditylang.org/linux-amd64/$ETHDEBUG_SOLC_BINARY"
+          echo "$ETHDEBUG_SOLC_SHA256  $HOME/.local/bin/solc-$ETHDEBUG_SOLC_VERSION" | sha256sum -c -
 
+          # Always needed: the legacy srcmap format test pins solc 0.8.16 (pre-ETHDebug).
           curl -fsSL \
             -o "$HOME/.local/bin/solc-0.8.16" \
             https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.16+commit.07a7930e
           echo "1632786c6c1f856a4a899232ec975a12f305118f43cce90e724ed0b2eebfeee1  $HOME/.local/bin/solc-0.8.16" | sha256sum -c -
 
-          chmod +x "$HOME/.local/bin/solc-0.8.31" "$HOME/.local/bin/solc-0.8.16"
-          ln -sf "$HOME/.local/bin/solc-0.8.31" "$HOME/.local/bin/solc"
+          chmod +x "$HOME/.local/bin/solc-$ETHDEBUG_SOLC_VERSION" "$HOME/.local/bin/solc-0.8.16"
+          # Some tests invoke bare `solc`, so point it at the version under test.
+          ln -sf "$HOME/.local/bin/solc-$ETHDEBUG_SOLC_VERSION" "$HOME/.local/bin/solc"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "SOLC_PATH=$HOME/.local/bin/solc-$ETHDEBUG_SOLC_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
         run: |

--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -1515,7 +1515,12 @@ struct TraceSourceIndex {
 
 impl TraceSourceIndex {
     fn load(spec: &ResolvedContractSpec) -> SoldbResult<Self> {
-        let metadata_path = spec.debug_dir.join("ethdebug.json");
+        let metadata_path = find_ethdebug_metadata(&spec.debug_dir).ok_or_else(|| {
+            soldb_core::SoldbError::Message(format!(
+                "No ETHDebug metadata file (ethdebug.json or ethdebug_resources.json) found in {}",
+                spec.debug_dir.display()
+            ))
+        })?;
         let runtime_path = find_runtime_ethdebug(&spec.debug_dir, &spec.name).ok_or_else(|| {
             soldb_core::SoldbError::Message(format!(
                 "No ETHDebug runtime file found in {}",
@@ -2221,6 +2226,17 @@ fn format_raw_stack(stack: &[String]) -> String {
         .join(" ")
 }
 
+fn find_ethdebug_metadata(root: &Path) -> Option<PathBuf> {
+    // Modern solc (>= ~0.8.32) renamed the global ETHDebug metadata file from
+    // `ethdebug.json` to `ethdebug_resources.json`; accept either.
+    [
+        root.join("ethdebug.json"),
+        root.join("ethdebug_resources.json"),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+}
+
 fn find_runtime_ethdebug(root: &Path, contract_name: &str) -> Option<PathBuf> {
     let named = root.join(format!("{contract_name}_ethdebug-runtime.json"));
     if named.exists() {
@@ -2839,7 +2855,7 @@ fn find_debug_dir_for_contract(base_dir: &Path, contract_name: &str) -> PathBuf 
     ];
     candidates
         .into_iter()
-        .find(|candidate| candidate.join("ethdebug.json").exists())
+        .find(|candidate| find_ethdebug_metadata(candidate).is_some())
         .unwrap_or_else(|| base_dir.to_path_buf())
 }
 
@@ -2878,7 +2894,12 @@ fn read_json_file(path: &Path) -> SoldbResult<serde_json::Value> {
 }
 
 fn ethdebug_resources_for_spec(spec: &ResolvedContractSpec) -> SoldbResult<serde_json::Value> {
-    let path = spec.debug_dir.join("ethdebug.json");
+    let path = find_ethdebug_metadata(&spec.debug_dir).ok_or_else(|| {
+        soldb_core::SoldbError::Message(format!(
+            "No ETHDebug metadata file (ethdebug.json or ethdebug_resources.json) found in {}",
+            spec.debug_dir.display()
+        ))
+    })?;
     let metadata = read_json_file(&path)?;
     ethdebug_resources_from_metadata(&path, &metadata)
 }
@@ -3056,9 +3077,8 @@ fn trace_debug_metadata(spec: &ResolvedContractSpec) -> TraceDebugMetadata {
         };
     }
 
-    let ethdebug_json = spec.debug_dir.join("ethdebug.json");
-    let compiler_version = read_json_file(&ethdebug_json)
-        .ok()
+    let compiler_version = find_ethdebug_metadata(&spec.debug_dir)
+        .and_then(|ethdebug_json| read_json_file(&ethdebug_json).ok())
         .and_then(|value| {
             value
                 .get("compilation")
@@ -3187,7 +3207,7 @@ fn simulation_source_file(args: &SimulateArgs, contract_name: &str) -> Option<St
         .into_iter()
         .find(|spec| spec.name == contract_name)
         .and_then(|spec| {
-            let ethdebug = spec.debug_dir.join("ethdebug.json");
+            let ethdebug = find_ethdebug_metadata(&spec.debug_dir)?;
             read_json_file(&ethdebug).ok().and_then(|value| {
                 value
                     .get("compilation")

--- a/crates/soldb-compiler/src/lib.rs
+++ b/crates/soldb-compiler/src/lib.rs
@@ -88,12 +88,38 @@ impl CompilerConfig {
     ) -> SoldbResult<CompilationResult> {
         let output_dir = output_dir.unwrap_or(&self.debug_output_dir);
         self.ensure_directories()?;
-        run_solc(
+        // solc >= ~0.8.32 dropped the `--ethdebug`/`--ethdebug-runtime` flags in favor of
+        // `--ethdebug-program`/`--ethdebug-program-runtime` (gated behind `--experimental`).
+        // Try the configured (legacy) flags first for compatibility with older/pinned solc
+        // installs, and fall back to the modern flag names only if solc specifically rejects
+        // the legacy ones - this keeps a single code path working across solc versions without
+        // needing to parse and hardcode a version cutoff.
+        match run_solc(
             &self.solc_path,
             &self.ethdebug_flags,
             contract_file.as_ref(),
             output_dir,
-        )
+        ) {
+            Ok(result) => Ok(result),
+            Err(SoldbError::Message(legacy_error))
+                if is_unrecognised_ethdebug_option(&legacy_error) =>
+            {
+                let modern_flags = modern_ethdebug_flags(&self.ethdebug_flags);
+                run_solc(
+                    &self.solc_path,
+                    &modern_flags,
+                    contract_file.as_ref(),
+                    output_dir,
+                )
+                .map_err(|modern_error| {
+                    SoldbError::Message(format!(
+                        "Compilation failed with legacy ETHDebug flags ({legacy_error}); \
+                             retry with modern ETHDebug flags also failed ({modern_error})"
+                    ))
+                })
+            }
+            Err(other) => Err(other),
+        }
     }
 
     pub fn compile_for_production(
@@ -387,12 +413,47 @@ fn run_solc(
     })
 }
 
+/// solc's replacement names for the ETHDebug flags it dropped (see
+/// `CompilerConfig::compile_with_ethdebug`). Kept as an explicit table rather than a
+/// string-pattern rewrite so it's obvious exactly which flags are affected.
+const MODERN_ETHDEBUG_REPLACEMENTS: &[(&str, &str)] = &[
+    ("--ethdebug", "--ethdebug-program"),
+    ("--ethdebug-runtime", "--ethdebug-program-runtime"),
+];
+
+fn modern_ethdebug_flags(flags: &[String]) -> Vec<String> {
+    let mut modern = Vec::with_capacity(flags.len() + 2);
+    modern.push("--experimental".to_owned());
+    for flag in flags {
+        let replacement = MODERN_ETHDEBUG_REPLACEMENTS
+            .iter()
+            .find(|(old, _)| *old == flag)
+            .map_or_else(|| flag.clone(), |(_, new)| (*new).to_owned());
+        modern.push(replacement);
+    }
+    // The old single `--ethdebug` flag also produced the global resources file
+    // (`ethdebug.json`); the modern API splits that out into its own opt-in flag.
+    if flags.iter().any(|flag| flag == "--ethdebug") {
+        modern.push("--ethdebug-resources".to_owned());
+    }
+    modern
+}
+
+fn is_unrecognised_ethdebug_option(error_message: &str) -> bool {
+    error_message.contains("unrecognised option") && error_message.contains("--ethdebug")
+}
+
 fn discover_output_files(output_dir: &Path) -> SoldbResult<CompilerOutputFiles> {
+    // Modern solc renames the global resources file from `ethdebug.json` to
+    // `ethdebug_resources.json`; accept either.
+    let global_ethdebug = [
+        output_dir.join("ethdebug.json"),
+        output_dir.join("ethdebug_resources.json"),
+    ]
+    .into_iter()
+    .find(|path| path.exists());
     let mut files = CompilerOutputFiles {
-        ethdebug: output_dir
-            .join("ethdebug.json")
-            .exists()
-            .then(|| output_dir.join("ethdebug.json")),
+        ethdebug: global_ethdebug,
         contracts: BTreeMap::new(),
     };
 

--- a/crates/soldb-dap/src/server.rs
+++ b/crates/soldb-dap/src/server.rs
@@ -602,7 +602,7 @@ struct SourceIndex {
 
 impl SourceIndex {
     fn load(root: &Path, contract_name: Option<String>) -> SoldbResult<Self> {
-        let metadata = read_json(root.join("ethdebug.json"))?;
+        let metadata = read_json(find_ethdebug_metadata(root)?)?;
         let runtime_path = find_runtime_ethdebug(root, contract_name.as_deref())?;
         let runtime = read_json(&runtime_path)?;
         let instructions = runtime
@@ -673,6 +673,23 @@ fn read_json(path: impl AsRef<Path>) -> SoldbResult<Value> {
     })?;
     serde_json::from_str(&content)
         .map_err(|error| SoldbError::Message(format!("Invalid JSON {}: {error}", path.display())))
+}
+
+fn find_ethdebug_metadata(root: &Path) -> SoldbResult<PathBuf> {
+    // Modern solc (>= ~0.8.32) renamed the global ETHDebug metadata file from
+    // `ethdebug.json` to `ethdebug_resources.json`; accept either.
+    [
+        root.join("ethdebug.json"),
+        root.join("ethdebug_resources.json"),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+    .ok_or_else(|| {
+        SoldbError::Message(format!(
+            "No ETHDebug metadata file (ethdebug.json or ethdebug_resources.json) found in {}",
+            root.display()
+        ))
+    })
 }
 
 fn find_runtime_ethdebug(root: &Path, contract_name: Option<&str>) -> SoldbResult<PathBuf> {

--- a/test/deploy-contract.sh
+++ b/test/deploy-contract.sh
@@ -165,6 +165,31 @@ echo -e "${BLUE}Running: $SOLC_PATH ${COMPILE_FLAGS[*]} $CONTRACT_FILE${NC}"
 
 # Check for errors
 COMPILE_EXIT_CODE=${PIPESTATUS[0]}
+
+# solc >= ~0.8.32 dropped the `--ethdebug`/`--ethdebug-runtime` flags in favor of
+# `--ethdebug-program`/`--ethdebug-program-runtime` (gated behind `--experimental`), and
+# moved the global resources output behind its own `--ethdebug-resources` flag. Retry with
+# the modern flag names if solc specifically rejected the legacy ones, rather than hardcoding
+# a version cutoff that will inevitably drift out of date again.
+if [ "$USE_ETHDEBUG" = true ] && [ $COMPILE_EXIT_CODE -ne 0 ] && grep -q "unrecognised option" "$DEBUG_DIR/compile.log" && grep -q -- "--ethdebug" "$DEBUG_DIR/compile.log"; then
+    echo -e "${YELLOW}Legacy ETHDebug flags not recognised by this solc; retrying with modern flag names...${NC}"
+    COMPILE_FLAGS=(
+        --via-ir
+        --debug-info ethdebug
+        --experimental
+        --ethdebug-program
+        --ethdebug-program-runtime
+        --ethdebug-resources
+        --bin
+        --abi
+        --overwrite
+        -o "$DEBUG_DIR"
+    )
+    echo -e "${BLUE}Running: $SOLC_PATH ${COMPILE_FLAGS[*]} $CONTRACT_FILE${NC}"
+    "$SOLC_PATH" "${COMPILE_FLAGS[@]}" "$CONTRACT_FILE" 2>&1 | tee "$DEBUG_DIR/compile.log"
+    COMPILE_EXIT_CODE=${PIPESTATUS[0]}
+fi
+
 if [ $COMPILE_EXIT_CODE -ne 0 ]; then
     if [ "$USE_ETHDEBUG" = true ]; then
         echo -e "${RED}ETHDebug compilation failed with exit code $COMPILE_EXIT_CODE${NC}"
@@ -178,9 +203,11 @@ fi
 # Verify output files were created
 if [ "$USE_ETHDEBUG" = true ]; then
     echo -e "\n${BLUE}Verifying ETHDebug output...${NC}"
-    
-    if [ ! -f "$DEBUG_DIR/ethdebug.json" ]; then
-        echo -e "${YELLOW}Warning: Main ethdebug.json file not found${NC}"
+
+    # Modern solc renames the global resources file from `ethdebug.json` to
+    # `ethdebug_resources.json`; accept either.
+    if [ ! -f "$DEBUG_DIR/ethdebug.json" ] && [ ! -f "$DEBUG_DIR/ethdebug_resources.json" ]; then
+        echo -e "${YELLOW}Warning: Main ethdebug.json/ethdebug_resources.json file not found${NC}"
     else
         echo -e "${GREEN}✓ Found ethdebug.json${NC}"
     fi

--- a/test/interact-contract.sh
+++ b/test/interact-contract.sh
@@ -24,8 +24,9 @@ get_debug_command() {
         abs_debug_dir="$(pwd)/$DEBUG_DIR"
     fi
     
-    # Check if ethdebug format is available
-    if [ -f "$abs_debug_dir/ethdebug.json" ]; then
+    # Check if ethdebug format is available. Modern solc renames the global resources file
+    # from `ethdebug.json` to `ethdebug_resources.json`; accept either.
+    if [ -f "$abs_debug_dir/ethdebug.json" ] || [ -f "$abs_debug_dir/ethdebug_resources.json" ]; then
         # Get contract address and name from deployment.json
         if [ -f "$abs_debug_dir/deployment.json" ]; then
             CONTRACT_ADDR=$(jq -r '.address' "$abs_debug_dir/deployment.json")

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -438,9 +438,10 @@ if [ "$RUN_TRACE_TESTS" = true ]; then
             "$LIT_CMD" $LIT_OPTS "${SCRIPT_DIR}/trace/increment-trace-legacy.test"
         fi
         
-        # Then run all other trace tests (they use solc 0.8.31)
-        # Ensure solc is set to 0.8.31 after legacy test may have changed it
-        echo -e "${BLUE}Running ETHDebug tests (solc 0.8.31)...${NC}"
+        # Then run all other trace tests (they need an ETHDebug-capable solc)
+        # Re-assert the ETHDebug compiler in case the legacy test changed it.
+        # ensure_ethdebug_solc reports the version actually selected.
+        echo -e "${BLUE}Running ETHDebug tests...${NC}"
         ensure_ethdebug_solc "$SOLC_PATH"
         export SOLC_PATH
         # Use lit's filter-out to exclude legacy test


### PR DESCRIPTION
solc >= ~0.8.32 replaced the experimental --ethdebug/--ethdebug-runtime flags with --ethdebug-program/--ethdebug-program-runtime/--ethdebug-resources behind --experimental, and renamed the global metadata file from ethdebug.json to ethdebug_resources.json. Both the compile step and the --ethdebug-dir loader failed against any newer solc as a result.

- soldb-compiler: retry with the modern flag names when solc rejects the legacy ones, instead of hardcoding a version cutoff.
- soldb-cli, soldb-dap: accept either ethdebug.json or ethdebug_resources.json wherever the global metadata file is read.
- test scripts: mirror the same retry and filename fallback.
- ci: run the lit suite against both solc 0.8.31 and 0.8.36 so the legacy and modern flag paths are both covered.