### PR TITLE
feat: add AGENTS.md with guidance for coding agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # The solc development branch moves without us, so check against it on a schedule as
+  # well as per pull request.
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
 
 env:
   FOUNDRY_VERSION: v1.0.0
@@ -130,6 +135,169 @@ jobs:
             cat anvil.log
             exit 1
           fi
+
+          RPC_URL=http://127.0.0.1:8545 ./test/run-tests.sh
+
+  lit-solc-develop:
+    # Forward-looking compatibility run against the Solidity development branch, where
+    # ETHDebug output is still taking shape - variable emission in particular lands there
+    # before it reaches any release, and it is what the debugger's `vars` and `print`
+    # commands read.
+    #
+    # Deliberately non-blocking: `develop` is a moving target we do not control, so a break
+    # there is an early warning for us, not a reason to hold up a soldb pull request. When
+    # this job goes red, read it before assuming the fault is ours.
+    name: lit (solc develop)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ env.FOUNDRY_VERSION }}
+
+      - name: Resolve the solc develop commit
+        id: solc-develop
+        run: |
+          set -euo pipefail
+          commit="$(git ls-remote https://github.com/argotorg/solidity.git refs/heads/develop | cut -f1)"
+          if [ -z "$commit" ]; then
+            echo "Could not resolve argotorg/solidity develop" >&2
+            exit 1
+          fi
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+          echo "Testing against argotorg/solidity@$commit"
+
+      - name: Restore the cached solc build
+        id: solc-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/solc-develop
+          key: solc-develop-${{ runner.os }}-${{ steps.solc-develop.outputs.commit }}
+
+      - name: Restore the compiler ccache
+        if: steps.solc-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: solc-develop-ccache-${{ runner.os }}-${{ steps.solc-develop.outputs.commit }}
+          restore-keys: solc-develop-ccache-${{ runner.os }}-
+
+      - name: Install compiler build dependencies
+        if: steps.solc-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential ccache cmake ninja-build \
+            libboost-filesystem-dev libboost-program-options-dev \
+            libboost-system-dev libboost-test-dev
+
+      - name: Build solc from develop
+        if: steps.solc-cache.outputs.cache-hit != 'true'
+        env:
+          SOLC_COMMIT: ${{ steps.solc-develop.outputs.commit }}
+        run: |
+          set -euo pipefail
+          git init solidity
+          cd solidity
+          git remote add origin https://github.com/argotorg/solidity.git
+          git fetch --depth 1 origin "$SOLC_COMMIT"
+          git checkout --detach FETCH_HEAD
+          # Only the submodules the compiler links against; the others are test-only.
+          git submodule update --init --depth 1 \
+            deps/nlohmann-json deps/range-v3 deps/fmtlib
+          # Build the compiler binary alone. PEDANTIC=OFF keeps a warning newly introduced
+          # on develop from failing the build, which would tell us nothing about soldb.
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DPEDANTIC=OFF \
+            -DTESTS=OFF \
+            -DTOOLS=OFF \
+            -DSTRICT_Z3_VERSION=OFF
+          cmake --build build --target solc
+          mkdir -p "$HOME/.local/bin"
+          install -m 755 build/solc/solc "$HOME/.local/bin/solc-develop"
+
+      - name: Install system test tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq llvm
+          LLVM_BIN="$(dirname "$(find /usr/lib/llvm-* -name FileCheck | sort -V | tail -1)")"
+          echo "$LLVM_BIN" >> "$GITHUB_PATH"
+
+      - name: Install lit
+        run: python -m pip install lit
+
+      - name: Select the Solidity compilers
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          # The legacy source-map test pins 0.8.16, which predates ETHDebug entirely.
+          curl -fsSL \
+            -o "$HOME/.local/bin/solc-0.8.16" \
+            https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.16+commit.07a7930e
+          echo "1632786c6c1f856a4a899232ec975a12f305118f43cce90e724ed0b2eebfeee1  $HOME/.local/bin/solc-0.8.16" | sha256sum -c -
+          chmod +x "$HOME/.local/bin/solc-0.8.16"
+          # Some tests invoke bare `solc`, so point it at the development build.
+          ln -sf "$HOME/.local/bin/solc-develop" "$HOME/.local/bin/solc"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "SOLC_PATH=$HOME/.local/bin/solc-develop" >> "$GITHUB_ENV"
+
+      - name: Report the ETHDebug output this build produces
+        run: |
+          set -euo pipefail
+          solc --version
+          # Informational, never a gate. `vars` and `print` in the debugger read ETHDebug
+          # variable locations, so record whether this build emits them yet.
+          out="$(mktemp -d)"
+          "$SOLC_PATH" --via-ir --debug-info ethdebug --experimental \
+            --ethdebug-program --ethdebug-program-runtime --ethdebug-resources \
+            --bin --abi --overwrite -o "$out" examples/Counter.sol > /dev/null 2>&1 \
+            || "$SOLC_PATH" --via-ir --debug-info ethdebug \
+              --ethdebug --ethdebug-runtime \
+              --bin --abi --overwrite -o "$out" examples/Counter.sol > /dev/null 2>&1 \
+            || echo "ETHDebug compilation failed with both flag generations"
+          runtime="$out/Counter_ethdebug-runtime.json"
+          if [ ! -f "$runtime" ]; then
+            echo "ETHDebug runtime artifact: not produced"
+          elif jq -e '[.instructions[]?.context?.variables?, .variables?] | flatten | map(select(. != null)) | length > 0' "$runtime" > /dev/null 2>&1; then
+            echo "ETHDebug variable locations: PRESENT - the debugger can decode locals"
+          else
+            echo "ETHDebug variable locations: not emitted by this build yet"
+          fi
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Build Rust binaries
+        run: cargo build --bin soldb --bin soldb-dap-server
+
+      - name: Run lit tests
+        run: |
+          set -euo pipefail
+          anvil --steps-tracing --host 127.0.0.1 --port 8545 > anvil.log 2>&1 &
+          ANVIL_PID=$!
+          trap 'kill "$ANVIL_PID"' EXIT
+
+          for _ in {1..30}; do
+            if curl -fsS \
+              -X POST \
+              -H "Content-Type: application/json" \
+              --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+              http://127.0.0.1:8545 > /dev/null; then
+              break
+            fi
+            sleep 1
+          done
 
           RPC_URL=http://127.0.0.1:8545 ./test/run-tests.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,469 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## Project Overview
+
+SolDB is an ETHDebug-first, LLDB-style debugger for Solidity and the EVM, written in
+Rust. It maps EVM execution back to Solidity source using compiler-generated debug
+information, and exposes that as a CLI (`trace`, `simulate`, `list-events`,
+`list-contracts`, `bridge`), an interactive REPL, a versioned JSON document for web
+clients, and a DAP server for editors.
+
+Two premises drive most design decisions:
+
+- **Debug info comes from the compiler, not from guessing.** We consume
+  `solc --debug-info ethdebug` artifacts. When metadata is missing or incomplete, the
+  right behavior is to degrade visibly (say what is unavailable), never to invent a
+  source mapping from heuristics. Legacy `srcmap` support exists only as a fallback for
+  pre-ETHDebug compilers.
+- **The node is the execution oracle.** We do not maintain chain state. Either the node
+  replays the transaction for us (`debug_traceTransaction`), or we pull the state a
+  transaction touched over normal RPC and replay it in REVM. Both paths must produce the
+  same `TransactionTrace` shape.
+
+Do not describe SolDB in the third person in code comments, docs, or commit messages.
+This repository is the project: say "we", "this codebase", or "the debugger" instead of
+"SolDB does" / "SolDB supports". User-facing docs (`README.md`, `docs/*.md`) are the
+exception and may name the product.
+
+## Commands
+
+```bash
+cargo build --workspace --all-targets                   # Build everything
+cargo test --workspace --all-targets                    # Rust unit + integration tests
+cargo fmt --all                                         # Format
+cargo clippy --workspace --all-targets -- -D warnings   # Lint (CI gate)
+cargo llvm-cov --workspace --all-targets --fail-under-lines 80   # Coverage gate
+./test/run-tests.sh                                     # lit/FileCheck end-to-end suite
+make test                                               # cargo test + lit
+cargo run --bin soldb -- trace <tx> --rpc http://127.0.0.1:8545  # Run the CLI
+```
+
+`cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check`
+are hard CI gates. Run both before proposing a change; neither needs a node.
+
+The lit suite is **not hermetic**. It needs a live node, compiles contracts with `solc`,
+deploys them, and sends transactions:
+
+```bash
+anvil --steps-tracing --host 127.0.0.1 --port 8545 &   # required
+cargo build --bin soldb                                # run-tests.sh picks up target/debug/soldb
+./test/run-tests.sh                                    # or SOLC_PATH=/path/to/solc ./test/run-tests.sh
+```
+
+`run-tests.sh` generates `test/lit.site.cfg.py` (gitignored) with the freshly deployed
+contract address and transaction hashes. **Run it at least once before invoking `lit`
+directly**, otherwise every substitution such as `%{test_tx}` is empty and tests fail for
+the wrong reason. After that, iterate on a single test with:
+
+```bash
+lit test/trace/basic-trace.test -v
+lit test/simulate/ -v
+```
+
+Scope a full run with `--trace-only`, `--simulate-only`, `--events-only`, or `--cli-only`.
+Tests run with `-j1` on purpose: they share one node, one contract deployment, and the
+`examples/out` artifact directory.
+
+Some tests are opt-in and silently skip without their prerequisites, so a green run does
+not mean full coverage:
+
+- `test/events/sepolia-*.test`, `test/trace/multi-contract-*sepolia.test` need
+  `--sepolia-key=KEY` or `SEPOLIA_KEY_ENV`; they gate on the `sepolia-rpc` lit feature.
+- `test/trace/stylus-interop.test` needs a nitro testnode, `cargo-stylus-beta`, and the
+  bridge on `127.0.0.1:8765`; it gates on the `stylus-bridge` feature. See
+  `test/stylus/README.md`.
+- `test/trace/increment-trace-legacy.test` pins `solc` 0.8.16 and is run separately by
+  `run-tests.sh` before the ETHDebug tests, because it switches the active compiler.
+
+Do not "fix" a skipped test by removing its `REQUIRES:` line.
+
+## Architecture
+
+Crate dependencies, as actually declared in `crates/*/Cargo.toml`:
+
+| crate | depends on |
+| --- | --- |
+| `soldb-core` | *(nothing)* |
+| `soldb-ethdebug` | core |
+| `soldb-rpc` | core, `revm` |
+| `soldb-repl` | core |
+| `soldb-serializer` | core |
+| `soldb-debugger` | core, ethdebug |
+| `soldb-bridge` | core, rpc |
+| `soldb-compiler` | core, ethdebug, rpc |
+| `soldb-dap` | core, ethdebug, rpc, repl, debugger |
+| `soldb-cli` | core, ethdebug, rpc, repl, debugger, serializer, compiler, bridge |
+
+`soldb-debugger` is the shared frontend model, and both `soldb-cli` and `soldb-dap` go
+through it for variable decoding so the terminal and an editor report the same values.
+The CLI still carries its own source-stepping and frame-building logic in `main.rs`,
+including a near-verbatim copy of `soldb-debugger`'s Solidity source-function parser.
+Prefer moving CLI logic *into* `soldb-debugger` over growing that second implementation;
+new frontend logic that both would want belongs there.
+
+- **soldb-core**: the shared vocabulary — `TraceStep`, `StepSnapshot`,
+  `TransactionTrace`, `TraceCapabilities`, `TraceArtifacts`, `SoldbError`. It has no
+  soldb dependencies and must stay that way; it is the type boundary every other crate
+  agrees on.
+- **soldb-ethdebug**: ETHDebug artifact loading (`metadata.rs`), legacy `srcmap` parsing
+  (`source_map.rs`), ABI encode/decode and signature parsing (`abi.rs`), event decoding
+  (`events.rs`). Pure functions over files and bytes; no network.
+- **soldb-rpc**: JSON-RPC transport, the `debug-rpc` backend, the REVM `replay` backend,
+  `debug_traceCall` simulation, and log retrieval. This is the only crate that talks to a
+  node.
+- **soldb-debugger**: source-step, function, and variable decoding over a
+  `TransactionTrace` plus `EthdebugInfo`. Frontend-agnostic; shared by CLI, REPL, and DAP.
+- **soldb-repl**: the interactive debugger *state machine* — breakpoints, stepping,
+  display mode. It owns no I/O; the CLI drives it and prints. Keep it that way, because
+  it is what makes REPL behavior unit-testable without a terminal.
+- **soldb-serializer**: the versioned web/JSON projection of traces and simulations.
+- **soldb-compiler**: `solc` invocation, ETHDebug artifact discovery, deploy helpers.
+- **soldb-bridge**: cross-VM bridge protocol and server (Stylus today).
+- **soldb-dap**: Debug Adapter Protocol server for editors.
+- **soldb-cli**: argument parsing, command dispatch, and *all* human-readable formatting.
+
+Pipeline: `tx hash -> backend (debug-rpc | replay) -> TransactionTrace -> ETHDebug
+enrichment -> call frames + source steps + decoded values -> CLI text | JSON | REPL | DAP`.
+
+### Layering Rules
+
+- Terminal formatting, ANSI color, and `println!` belong in `soldb-cli`. A library crate
+  that prints is a library crate that cannot be reused by the DAP server or the JSON
+  path. If a library needs to report something, return it.
+- Backend-specific quirks stay inside `soldb-rpc` behind `TraceBackend`. Everything above
+  it reads `TraceCapabilities` to decide what it can show — never `backend == "replay"`.
+  Adding a backend must not require touching the CLI.
+- ETHDebug parsing stays in `soldb-ethdebug`. If the CLI is indexing into raw ETHDebug
+  JSON, the accessor is missing from the metadata layer.
+- `soldb-core` types are a serialization contract with on-disk artifacts and web clients.
+  Adding a field is additive and needs `#[serde(default)]`; renaming or removing one is a
+  breaking change (see JSON Output Contract).
+
+### Big Files
+
+`crates/soldb-cli/src/main.rs` (~4000 lines) and `crates/soldb-rpc/src/lib.rs` (~3200
+lines) are the two outliers. Prefer adding to a focused module over growing them further;
+when you touch a coherent region of either, splitting that region into its own module is
+a welcome change as long as it is a pure move with no behavior delta.
+
+## ETHDebug Notes
+
+### Instruction Shape
+
+An ETHDebug runtime artifact is a list of instructions, each with its program counter
+(`offset`) and a `context` describing where it came from:
+
+```json
+{
+  "offset": 5,
+  "operation": {"mnemonic": "PUSH1", "arguments": ["0x04"]},
+  "context": {"code": {"source": {"id": 0}, "range": {"offset": 144, "length": 2771}}}
+}
+```
+
+**Source spans nest, and a span that contains a line is not a span generated for it.**
+The compiler attaches a whole-contract range to dispatcher and preamble instructions, so
+that range intersects every line in the file. Any code that resolves a source line to a
+program counter has to rank candidates — prefer spans that *begin* on the line, and fall
+back to the narrowest intersecting span — or it will resolve every line to the first
+instruction of the contract. `TraceSourceIndex::resolve_breakpoint` in
+`crates/soldb-cli/src/main.rs` is the reference implementation.
+
+### Variables
+
+`EthdebugInfo::variables_at_pc` reads `context.variables` on each instruction (and the
+artifact's top-level `variables` array). Not every compiler release emits either yet —
+solc 0.8.36 does not — so variable inspection legitimately reports nothing in scope on
+those compilers. That is a debug-info gap, and the correct behavior is to say so rather
+than to guess values from the stack. Do not "fix" it by inferring locations.
+
+### Artifacts
+
+Artifacts produced per contract in the output directory:
+
+- `<Contract>_ethdebug.json` — creation-code debug info.
+- `<Contract>_ethdebug-runtime.json` — runtime debug info; this is what PC-to-source
+  mapping uses for an ordinary call.
+- `ethdebug.json` (legacy) / `ethdebug_resources.json` (modern) — the global resource
+  file listing sources.
+- `<Contract>.abi`, `<Contract>.bin` — ABI and bytecode.
+
+### Compiler Channels
+
+CI runs the lit suite against three compilers, for three different reasons:
+
+| channel | why |
+| --- | --- |
+| solc 0.8.31 (pinned) | the legacy `--ethdebug`/`--ethdebug-runtime` flag generation |
+| solc 0.8.36 (pinned) | the modern `--experimental --ethdebug-program …` generation |
+| solc `develop`, built from source | where ETHDebug output changes first |
+
+The `develop` job builds `argotorg/solidity@develop`, caches the binary by commit, and is
+**non-blocking** (`continue-on-error: true`): that branch moves without us, so a break
+there is an early warning, not a reason to hold up a pull request. It also runs on a daily
+schedule so a change lands in front of us without needing a soldb pull request, and it
+prints whether the build emits ETHDebug variable locations yet — the thing `vars` and
+`print` read. As of `f985208` it does not; instruction `context` carries only `code`.
+
+Development builds report a prerelease version such as `0.8.37-develop.2026.8.22`. The
+version gate reads only the leading `major.minor.patch`; do not reintroduce a parser that
+chokes on the suffix, or the one compiler that matters most for new ETHDebug output gets
+rejected as unsupported.
+
+**solc flag drift is a real, tested compatibility surface.** Older compilers accept
+`--ethdebug --ethdebug-runtime`; solc dropped those around 0.8.32 in favor of
+`--experimental --ethdebug-program --ethdebug-program-runtime --ethdebug-resources`.
+`CompilerConfig::compile_with_ethdebug` tries the legacy flags and falls back on the
+modern ones *only* when solc reports an unrecognised option, deliberately avoiding a
+hardcoded version cutoff. CI runs the whole lit suite twice, once per flag generation
+(solc 0.8.31 and 0.8.36 in `.github/workflows/ci.yml`).
+
+When you change compiler invocation or artifact discovery, verify against both
+generations. Do not add a version-number branch where a capability probe works.
+
+A contract is addressed on the command line as `--ethdebug-dir <address>:<name>:<dir>`;
+`--multi-contract` takes a JSON manifest. Address matching is case-insensitive and
+checksum-agnostic — normalize before comparing.
+
+## Testing
+
+Two layers, with different jobs:
+
+- **Rust tests** (`#[test]` in-crate, plus `crates/soldb-cli/tests/trace_cli.rs`) cover
+  pure logic: ABI encoding, signature parsing, source-map math, REPL state transitions,
+  trace construction from a canned `debug_traceTransaction` payload, backend selection.
+  These must not need a node. If a new behavior can be tested here, test it here —
+  it runs in every CI job and counts toward the 80% line-coverage gate.
+- **lit + FileCheck tests** (`test/**/*.test`) cover end-to-end CLI behavior against a
+  real node and real solc output: exact rendered output, exit codes, JSON documents,
+  error messages. Prefer these for anything user-visible.
+
+**Backend parity is itself a test target.** `test/trace/replay-*.test` run the same
+transaction through `--backend debug-rpc` and `--backend replay` and diff the opcode
+streams and the JSON step snapshots. Any change to how a `TraceStep` is built has to keep
+the two backends producing identical output, including incidental formatting: memory is
+normalized to one unprefixed hex string precisely because nodes disagree about whether
+`structLogs` memory words carry a `0x` prefix.
+
+Line coverage is enforced at 80% for the Rust workspace. Lit tests do not contribute to
+it, so a feature implemented only behind a lit test can push coverage down — add unit
+tests for the logic underneath.
+
+### Writing lit Tests
+
+```bash
+# Short description of what this covers
+# REQUIRES: soldb
+# RUN: %soldb trace %{test_tx} --ethdebug-dir %{contract_address}:TestContract:%{ethdebug_dir} --rpc %{rpc_url} 2>&1 | FileCheck %s
+
+# CHECK: Contract: TestContract
+# CHECK: Call Stack:
+# CHECK: #0 TestContract::runtime_dispatcher
+```
+
+Substitutions available (defined in `test/lit.cfg.py`, filled by `run-tests.sh`):
+`%soldb`, `%{rpc_url}`, `%{sepolia_rpc_url}`, `%{contract_address}`, `%{test_tx}`,
+`%{test_tx_no_events}`, `%{deploy_tx}`, `%{ethdebug_dir}`, `%{solc_path}`,
+`%{private_key}`, `%{chain_id}`, `%{project_root}`, and the `%{stylus_*}` set.
+
+Conventions:
+
+- Every test starts with `# REQUIRES: soldb`. Add `# REQUIRES: sepolia-rpc` or
+  `# REQUIRES: stylus-bridge` for tests that need those environments.
+- Put the test in the directory that matches the command under test: `test/trace/`,
+  `test/simulate/`, `test/events/`, `test/cli/`, `test/stylus/`.
+- Expect failures explicitly with `not %soldb ...` rather than letting a nonzero exit
+  fail the RUN line.
+- Pipe `2>&1` when the assertion covers diagnostics; SolDB writes progress and errors to
+  stderr and results to stdout.
+- For JSON output, pipe through `jq` before FileCheck when you care about one field, so
+  the test does not break on unrelated additive schema changes.
+
+### FileCheck Guidance
+
+Follow the [FileCheck reference](https://llvm.org/docs/CommandGuide/FileCheck.html).
+
+- Put checks immediately above or beside the behavior they cover, and keep patterns short
+  — match the distinguishing part of a line, not the whole line.
+- `CHECK` is ordered. Use `CHECK-DAG` for output whose order is not part of the contract
+  (help text flags, event fields), `CHECK-NEXT` when adjacency *is* the contract (call
+  stack nesting), and `CHECK-NOT` to pin an absence.
+- Capture varying values with `[[NAME:regex]]` and reuse them as `[[NAME]]`. Gas numbers,
+  addresses, and transaction hashes change between runs — never hardcode them.
+- Use `--check-prefix` only when one file drives several distinct invocations (as
+  `test/cli/help.test` does). With a single invocation, use the default `CHECK`.
+- lit substitutions are regular expressions applied to the whole RUN line, and this suite
+  substitutes the bare word `not` (to LLVM's `not` binary). It is anchored with `\bnot\b`,
+  so identifiers like `cannot_find` are safe, but a `not` surrounded by non-word
+  characters will still be rewritten. If a RUN line mangles itself, check the
+  substitution list in `test/lit.cfg.py` before suspecting the code.
+- Keep each check specific enough to fail for the bug it covers. `# CHECK: Gas used:` is
+  a shape assertion; if the test exists to pin a value, capture and assert the value.
+
+## CLI Output and Error Style
+
+The CLI is a developer tool: output is read under time pressure, often after something
+already went wrong.
+
+- Errors do not end with a full stop, and start lowercase unless the first word is a
+  proper noun or a literal.
+- Refer to code, flags, files, and identifiers in backticks: `` `--ethdebug-dir` ``, not
+  `"--ethdebug-dir"`.
+- The main message is one line and says what failed. Detail goes on follow-up lines.
+- Say what to do next when there is a next step. "no ETHDebug metadata for `0xabc…`; pass
+  `--ethdebug-dir <address>:<contract>:<dir>`" beats "metadata not found".
+- Never claim a capability that is not there. If the backend gave us no storage, the
+  storage view says so; it does not render an empty map as if it were the truth.
+- Respect `NO_COLOR`, `CLICOLOR_FORCE`, and non-TTY stdout — go through the existing
+  `paint`/`bold`/`info` helpers in `crates/soldb-cli/src/main.rs` rather than emitting raw
+  escapes, or lit tests will match against ANSI noise.
+- Human-readable output goes to stdout (including progress lines such as
+  `Loading transaction`); the final error message from `main` goes to stderr. `--json`
+  and `--json-events` paths print *only* the JSON document, so `soldb trace … --json | jq`
+  stays usable — keep it that way. Never add a progress `println!` that is not gated on
+  the JSON flag.
+- On failure the process exits with code `2`, not `1`. Lit tests that expect failure use
+  `not %soldb …`.
+
+Errors flow as `SoldbResult<T>` from `soldb-core`. When you add a failure path, produce a
+message that would let a user fix it without reading our source. Do not branch on error
+*text* — if a caller needs to distinguish a failure, give it a distinguishable error.
+A command that has already rendered its failure (the `--json` paths print a JSON error
+document) returns `SoldbError::AlreadyReported` so `main` exits non-zero without printing
+a second time.
+
+**A failed ETHDebug load is never silent.** The user asked for debug info by naming a
+directory; degrading to a raw opcode view without saying why produces a symptom identical
+to a contract compiled without debug info, which is the worst outcome for this tool.
+Load metadata through `load_source_index` and resolve specs through
+`resolve_contract_specs_reporting`: both report once to stderr via `report_once` and then
+degrade. Resolving *zero* contracts from a spec the user typed is a failure too, not an
+empty result. Never reintroduce a bare `TraceSourceIndex::load(spec).ok()` or
+`resolve_contract_specs(..).unwrap_or_default()`.
+
+## JSON Output Contract
+
+`soldb trace --json` and `soldb simulate --json` are consumed by web clients and
+explorers. `docs/json.md` is the specification; update it in the same change as the code.
+
+- `schemaVersion` increments only on a breaking change. Adding a field is not breaking.
+- New fields must round-trip through `serde` with `#[serde(default)]` so older artifacts
+  still deserialize.
+- Capability flags exist so clients can degrade gracefully. When a backend gains or loses
+  data, update `TraceCapabilities` — do not let clients infer it from `backend`.
+- Any change to the emitted document needs a lit test that pins it (see
+  `test/trace/json-trace.test`, `test/simulate/json-simulate.test`).
+
+## Commit Messages
+
+Follow the GitHub **50/72 rule**:
+
+- The subject line is at most **50 characters**, imperative, sentence-case, with no
+  trailing period: `Support solc versions that dropped --ethdebug`.
+- Separate the subject from the body with a blank line.
+- Wrap every body line at **72 characters**.
+
+Beyond the rule:
+
+- An optional lowercase scope prefix is common and welcome for narrow changes:
+  `cli: improve trace output`, `ci: fix clippy`, `soldb-repl: add resource info command`.
+  The prefix counts toward the 50-character subject budget.
+- Include a body for bug fixes, behavior changes, and anything non-obvious: what was
+  wrong, why the fix is right. Skip it for mechanical changes.
+- Check recent `git log` and match the surrounding style before committing.
+
+## PR Titles and Descriptions
+
+- Title follows the commit-subject rules above.
+- Describe what changed and why in prose. Link the issue or PR it relates to.
+- Include real measurements only; no invented numbers.
+- No templates, no testing boilerplate ("Validated with…", command dumps) unless asked.
+- Never pass escaped `\n` in a PR body — use a heredoc or a file so newlines are real.
+
+## Code Style
+
+- Comments are full sentences ending with a period (except URLs and code fragments).
+- Files end with a trailing newline.
+- Follow the patterns already in the file you are editing.
+- Never commit secrets, private keys, or API keys. The Anvil dev key in `test/` is the
+  well-known public one and is fine; nothing else is.
+
+### Rust
+
+- `unsafe_code = "forbid"` is set workspace-wide. Do not introduce `unsafe`, and do not
+  add a crate-level override.
+- Doc comments come before attributes: `/// ...` then `#[derive(...)]`.
+- Module docs are inner comments (`//! ...`) at the top of the module file, not `///` on
+  the `mod` item in the parent.
+- All `use` statements go at the top of the file, grouped: `std`, then external crates,
+  then `soldb_*`, then `crate`/`self`. Never import inside a function unless `#[cfg(...)]`
+  gating requires it. Test-only imports go inside `#[cfg(test)] mod tests`.
+- The workspace is **edition 2021**, so let-chains
+  (`if let Some(a) = a && let Some(b) = b`) do not compile here — they are edition 2024
+  only. Do not reach for them; the compiler error is `let chains are only allowed in Rust
+  2024 or later`.
+- Prefer `let Some(x) = x else { return ... };` over `match x { Some(x) => x, _ => ... }`,
+  and use it as the default for gating on several optional values in sequence, since it
+  keeps the happy path unindented and is the closest edition-2021 equivalent of a
+  let-chain. Match on a tuple (`match (a, b) { (Some(a), Some(b)) => ..., _ => ... }`)
+  when the values must be tested together.
+- Never reach for `ref` / `ref mut` in patterns; borrow the scrutinee with `&` / `&mut`.
+- Skip type annotations the compiler can infer. When a hint is genuinely needed, prefer
+  turbofish (`Vec::<String>::new()`) over an annotated binding.
+- Return `SoldbResult<T>`. In library crates, `unwrap`/`expect`/`panic!` are only
+  acceptable on an invariant that cannot depend on input — and then say why in the
+  message. Anything derived from RPC responses, ETHDebug JSON, ABI input, or user
+  arguments is untrusted: propagate an error instead.
+- Do not silently swallow failures. `let _ = ...`, `.ok()`, and `unwrap_or_default()` on
+  a fallible call hide exactly the bugs this tool exists to find; if a failure is
+  genuinely tolerable, leave a comment saying why.
+- `#[must_use]` on constructors and pure accessors that return data.
+
+## Notes
+
+- **Trace steps are the hot loop.** A mainnet transaction is easily hundreds of thousands
+  of `TraceStep`s, each carrying a stack `Vec<String>` and all of memory as a hex string.
+  Avoid per-step `clone()`, `format!`, and `String`-keyed map lookups in anything that
+  walks the full trace; borrow, and hoist allocation out of the loop.
+- **Read a step's state with `TraceStep::snapshot_ref`, never `normalized_snapshot`.**
+  The borrowed view costs nothing; the owned one copies the stack, all of memory, and the
+  storage map. Reach for `normalized_snapshot` only where ownership is genuinely required.
+  The same rule applies to the flat `step.stack`/`step.memory`/`step.storage` fields: go
+  through `snapshot_ref`, which also reads correctly for a step that carries only a
+  snapshot.
+- **Do not materialize a trace to answer a question about it.** `DebugTraceResult::steps`
+  builds every `TraceStep`; calling it to compute a flag or a count costs a full second
+  copy of the trace. Read the raw `struct_logs` instead, and pin the result against the
+  definition it replaces with a test.
+- **Known cost, not yet addressed:** a `TraceStep` stores its stack, memory, and storage
+  twice — once in the flat fields and once in `snapshot` — because both are serialized.
+  That duplication dominates peak memory on large traces (a 500k-step trace peaks around
+  8 GiB). Removing it means changing the `soldb-core` serialization contract, so it is a
+  deliberate decision rather than a cleanup.
+- **PC-to-source lookups should be indexed, not scanned.** Build the PC map once per
+  contract (`build_pc_to_instruction_map`) and reuse it; a linear scan per step turns a
+  trace walk quadratic.
+- **Addresses and hashes are user input.** Normalize case and `0x` prefixes at the edge,
+  once, and keep one canonical form internally.
+- **Hex from a node is not guaranteed to be ASCII.** Never slice a hex string by byte
+  offset (`&value[2..6]`, `&hex[i..i + 2]`); a multi-byte character straddling the
+  boundary panics. Decode over `as_bytes()` or take `chars()`.
+- **ABI offsets and lengths are attacker-controlled.** Event data and calldata carry
+  32-byte words that become `usize` offsets and lengths. Add them with `checked_add`,
+  multiply with `checked_mul`, index with `get(..)`, and bound any `with_capacity` against
+  the data actually present. Unchecked, they panic in debug and wrap in release into a
+  reversed slice range or a multi-terabyte reservation.
+- **Structures deserialized from JSON are not guaranteed acyclic.** Trace artifacts reach
+  us from backends and from trace files; recursive walks over their parent links need a
+  visited set, because a stack overflow aborts the process and no caller can catch it.
+- **`examples/out*` and `test/Output` are generated.** They are gitignored build output
+  from the test runner; never hand-edit them or commit them.
+- **Stale Python leftovers.** `src/`, `test/unit/`, and `test/integration/` still contain
+  `__pycache__`/egg-info from the pre-Rust implementation and are untracked. The runtime
+  is Rust-only (`docs/port-to-rust.md`); do not add code there or resurrect the Python
+  paths.
+- **Keep the docs honest.** `docs/commands.md` documents REPL commands including the
+  places where behavior is still a stub (`next` and `step` currently advance one
+  instruction). If you change that behavior, change the doc in the same commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,6 +2559,7 @@ dependencies = [
  "soldb-bridge",
  "soldb-compiler",
  "soldb-core",
+ "soldb-debugger",
  "soldb-ethdebug",
  "soldb-repl",
  "soldb-rpc",

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ soldb trace <tx_hash> --ethdebug-dir <contract_address>:<contract_name>:./out --
 
 Inside REPL:
 ```
-(soldb) break TestContract.sol:42
-(soldb) next
-(soldb) print balance
+soldb> break TestContract.sol:42
+soldb> next
+soldb> print balance
 ```
 
 ---
@@ -116,9 +116,9 @@ soldb simulate <contract_address> "increment(uint256)" 5     --from <sender_addr
 
 Inside REPL:
 ```
-(soldb) break TestContract.sol:38
-(soldb) step
-(soldb) vars
+soldb> break TestContract.sol:38
+soldb> step
+soldb> vars
 ```
 
 ---
@@ -126,6 +126,8 @@ Inside REPL:
 ## Features
 
 - ETHDebug-first source debugging built around compiler-generated `solc --debug-info ethdebug` metadata
+- Source-level variable inspection (`vars`, `print <name>`) in both the REPL and the DAP
+  server, decoded from ETHDebug variable locations
 - Full transaction traces with internal calls & decoded parameters
 - Transaction simulation with arbitrary calldata (including structs & tuples)
 - Interactive LLDB-like REPL (`step`, `break`, `print`, etc.) – works for both transactions and simulations

--- a/README.md
+++ b/README.md
@@ -266,6 +266,15 @@ Run the full local test target:
 make test
 ```
 
+CI additionally runs the lit suite against `solc` built from the
+[Solidity development branch](https://github.com/argotorg/solidity), where ETHDebug output
+changes first. That job is non-blocking and also runs on a daily schedule. To reproduce it
+locally, point the runner at your own build:
+
+```bash
+./test/run-tests.sh SOLC_PATH=/path/to/solidity/build/solc/solc
+```
+
 ### Coverage
 
 Line coverage is enforced at 80% in CI.

--- a/crates/soldb-bridge/src/lib.rs
+++ b/crates/soldb-bridge/src/lib.rs
@@ -1,3 +1,13 @@
+//! The cross-environment debugging bridge.
+//!
+//! Ethereum transactions increasingly span execution environments. This crate defines
+//! the protocol that lets a non-EVM debugger attach to the same trace and call-stack
+//! model SolDB uses for Solidity, along with the contract registry, the trace store, and
+//! the HTTP server that hosts them. Stylus is the first integrated environment; others
+//! follow the same shape.
+//!
+//! [`PROTOCOL_VERSION`] is the wire version peers negotiate against.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{Read, Write};

--- a/crates/soldb-cli/Cargo.toml
+++ b/crates/soldb-cli/Cargo.toml
@@ -16,6 +16,7 @@ serde_json.workspace = true
 soldb-bridge = { path = "../soldb-bridge" }
 soldb-compiler = { path = "../soldb-compiler" }
 soldb-core = { path = "../soldb-core" }
+soldb-debugger = { path = "../soldb-debugger" }
 soldb-ethdebug = { path = "../soldb-ethdebug" }
 soldb-repl = { path = "../soldb-repl" }
 soldb-rpc = { path = "../soldb-rpc" }

--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -1114,8 +1114,9 @@ fn print_current_debugger_step(state: &DebuggerState) {
         number_color(step.pc),
         opcode_color(&step.op)
     );
-    if !step.stack.is_empty() {
-        println!("{} {}", info("Stack:"), format_stack(&step.stack));
+    let stack = step.snapshot_ref().stack;
+    if !stack.is_empty() {
+        println!("{} {}", info("Stack:"), format_stack(stack));
     }
 }
 
@@ -1307,7 +1308,7 @@ fn list_contracts_command(args: &ListContractsArgs) -> SoldbResult<()> {
         if !matches!(step.op.as_str(), "CALL" | "DELEGATECALL" | "STATICCALL") {
             continue;
         }
-        let Some(address_word) = call_target_stack_word(&step.stack) else {
+        let Some(address_word) = call_target_stack_word(step.snapshot_ref().stack) else {
             continue;
         };
         let Some(address) = extract_address_from_stack_word(address_word) else {
@@ -1447,15 +1448,15 @@ fn print_raw_trace(trace: &TransactionTrace, args: &TraceArgs) {
     };
 
     for (index, step) in trace.steps.iter().take(max_steps).enumerate() {
-        let snapshot = step.normalized_snapshot();
+        let snapshot = step.snapshot_ref();
         println!(
             "{} | {} | {} | {} | {} | {}",
             number_color(format!("{index:>4}")),
             number_color(format!("{:>4}", step.pc)),
             opcode_color(format!("{:<14}", step.op)),
             success(format!("{:>8}", step.gas)),
-            format_stack(&snapshot.stack),
-            format_snapshot_state(&snapshot)
+            format_stack(snapshot.stack),
+            format_snapshot_state(snapshot)
         );
     }
 }
@@ -1488,15 +1489,15 @@ fn print_raw_simulation(trace: &TransactionTrace, args: &SimulateArgs, contract_
     };
 
     for (index, step) in trace.steps.iter().take(max_steps).enumerate() {
-        let snapshot = step.normalized_snapshot();
+        let snapshot = step.snapshot_ref();
         println!(
             "{} | {} | {} | {} | {} | {}",
             number_color(format!("{index:>4}")),
             number_color(format!("{:>4}", step.pc)),
             opcode_color(format!("{:<14}", step.op)),
             success(format!("{:>8}", step.gas)),
-            format_stack(&snapshot.stack),
-            format_snapshot_state(&snapshot)
+            format_stack(snapshot.stack),
+            format_snapshot_state(snapshot)
         );
     }
 }
@@ -2031,7 +2032,7 @@ fn build_call_frames(
                 source_params: function.params.clone(),
                 source_path: index.info.sources.get(&function.source_id).cloned(),
                 source_line: Some(function.declaration_line),
-                raw_stack: step.stack.clone(),
+                raw_stack: step.snapshot_ref().stack.to_vec(),
                 internal: false,
             });
         }
@@ -3463,9 +3464,9 @@ fn format_stack(stack: &[String]) -> String {
     items.join(" ")
 }
 
-fn format_snapshot_state(snapshot: &soldb_core::StepSnapshot) -> String {
+fn format_snapshot_state(snapshot: soldb_core::StepSnapshotRef<'_>) -> String {
     let mut items = Vec::new();
-    if let Some(memory) = &snapshot.memory {
+    if let Some(memory) = snapshot.memory {
         if !memory.is_empty() {
             items.push(format!("mem={}b", memory.len() / 2));
         }

--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -1604,7 +1604,7 @@ impl TraceSourceIndex {
                     && function.declaration_start <= location.offset
                     && location.offset <= function.body_end
             })
-            .min_by_key(|function| function.body_end - function.declaration_start)
+            .min_by_key(|function| function.body_end.saturating_sub(function.declaration_start))
     }
 
     fn descriptor_for_calldata(&self, calldata: &str) -> Option<CallDescriptor> {
@@ -3397,11 +3397,17 @@ fn format_snapshot_state(snapshot: &soldb_core::StepSnapshot) -> String {
 }
 
 fn shorten_hex(value: &str) -> String {
-    if value.len() > 10 && value.starts_with("0x") {
-        format!("0x{}...", &value[2..6])
-    } else {
-        value.to_owned()
+    // Stack and memory words come straight from the node, so they are not guaranteed to be
+    // ASCII hex. Take characters rather than byte offsets: `&value[2..6]` panics when byte
+    // 6 lands inside a multi-byte character.
+    let Some(digits) = value.strip_prefix("0x") else {
+        return value.to_owned();
+    };
+    if value.len() <= 10 {
+        return value.to_owned();
     }
+    let head = digits.chars().take(4).collect::<String>();
+    format!("0x{head}...")
 }
 
 #[cfg(test)]
@@ -3593,6 +3599,22 @@ mod tests {
 
         assert_eq!(resolved.pc, 64);
         assert_eq!(resolved.line, 2);
+    }
+
+    #[test]
+    fn shortening_hex_handles_non_ascii_values() {
+        // Trace values are whatever the node sent us. Slicing bytes 2..6 panicked when a
+        // multi-byte character straddled byte 6.
+        assert_eq!(
+            shorten_hex("0x\u{20ac}\u{20ac}\u{20ac}\u{20ac}\u{20ac}"),
+            "0x\u{20ac}\u{20ac}\u{20ac}\u{20ac}..."
+        );
+        assert_eq!(shorten_hex("0x1234"), "0x1234");
+        assert_eq!(shorten_hex("not hex at all"), "not hex at all");
+        assert_eq!(
+            shorten_hex("0x00000000000000000000000000000000000000000000000000000000000000ff"),
+            "0x0000..."
+        );
     }
 
     #[test]

--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -1624,7 +1624,12 @@ impl TraceSourceIndex {
         current_step: usize,
     ) -> Result<ResolvedSourceBreakpoint, String> {
         let source_ids = self.resolve_source_ids(target)?;
-        let mut candidates = Vec::<ResolvedSourceBreakpoint>::new();
+        // Rank every instruction whose source span touches the line. A span that *begins*
+        // on the line describes code generated for that line; a span that merely contains
+        // it can be an enclosing range. solc attributes the dispatcher preamble to the
+        // whole contract, and that range intersects every line, so ranking is what keeps
+        // `break File.sol:N` from resolving to the contract's first instruction for any N.
+        let mut ranked = Vec::<(bool, u64, ResolvedSourceBreakpoint)>::new();
 
         for source_id in source_ids {
             let Some(source) = self.source_contents.get(&source_id) else {
@@ -1648,20 +1653,38 @@ impl TraceSourceIndex {
                     .get(&source_id)
                     .cloned()
                     .unwrap_or_else(|| format!("source:{source_id}"));
-                candidates.push(ResolvedSourceBreakpoint {
-                    pc: instruction.offset,
-                    path,
-                    line: target.line,
-                });
+                ranked.push((
+                    span_starts_on_line(source, &location, target.line),
+                    location.length,
+                    ResolvedSourceBreakpoint {
+                        pc: instruction.offset,
+                        path,
+                        line: target.line,
+                    },
+                ));
             }
         }
 
-        if candidates.is_empty() {
+        let Some(&(starts_on_line, narrowest, _)) = ranked
+            .iter()
+            .min_by_key(|(starts_on_line, length, _)| (!*starts_on_line, *length))
+        else {
             return Err(match &target.file {
                 Some(file) => format!("no instruction maps to {file}:{}", target.line),
                 None => format!("no instruction maps to line {}", target.line),
             });
-        }
+        };
+
+        // Keep every instruction generated for the line. When nothing starts on the line
+        // the target sits inside a multi-line construct, so keep only the tightest spans
+        // and let wider enclosing ranges lose.
+        let candidates = ranked
+            .into_iter()
+            .filter(|(candidate_starts, length, _)| {
+                *candidate_starts == starts_on_line && (starts_on_line || *length == narrowest)
+            })
+            .map(|(_, _, candidate)| candidate)
+            .collect::<Vec<_>>();
 
         for step in trace.steps.iter().skip(current_step.saturating_add(1)) {
             if let Some(candidate) = candidates
@@ -1683,10 +1706,13 @@ impl TraceSourceIndex {
             }
         }
 
-        Ok(candidates
+        candidates
             .into_iter()
             .min_by_key(|candidate| candidate.pc)
-            .expect("candidates are non-empty"))
+            .ok_or_else(|| match &target.file {
+                Some(file) => format!("no instruction maps to {file}:{}", target.line),
+                None => format!("no instruction maps to line {}", target.line),
+            })
     }
 
     fn resolve_source_ids(&self, target: &SourceBreakpointTarget) -> Result<Vec<u64>, String> {
@@ -1725,6 +1751,15 @@ fn source_path_matches(source_path: &str, requested: &str) -> bool {
             .file_name()
             .and_then(|name| name.to_str())
             .is_some_and(|name| name == requested)
+}
+
+/// Reports whether an ETHDebug source span begins on `line`.
+///
+/// Spans that begin on the requested line are the instructions solc generated for it;
+/// spans that only contain the line are enclosing ranges such as the whole-contract span
+/// attached to the dispatcher preamble.
+fn span_starts_on_line(source: &str, location: &SourceLocation, line: u64) -> bool {
+    line_for_offset(source, location.offset as usize) == line
 }
 
 fn span_intersects_line(source: &str, location: &SourceLocation, line: u64) -> bool {
@@ -3471,6 +3506,93 @@ mod tests {
             multi_contract: false,
             json_events: false,
         }
+    }
+
+    fn instruction_at(pc: u64, offset: u64, length: u64) -> Instruction {
+        Instruction {
+            offset: pc,
+            operation: serde_json::json!({"mnemonic": "JUMPDEST"}),
+            context: Some(serde_json::json!({
+                "code": {"source": {"id": 0}, "range": {"offset": offset, "length": length}}
+            })),
+        }
+    }
+
+    #[test]
+    fn source_breakpoints_prefer_the_span_generated_for_the_line() {
+        // Three source lines; the statement for line 2 starts at byte 10.
+        let source = "contract C {\n  uint x = 1;\n}\n";
+        let line_two_offset = source.find("uint").expect("line two statement") as u64;
+
+        let info = EthdebugInfo {
+            compilation: serde_json::Value::Null,
+            contract_name: "C".to_owned(),
+            environment: "runtime".to_owned(),
+            instructions: vec![
+                // The dispatcher preamble solc attributes to the whole contract. Its span
+                // intersects every line, so it used to win every source breakpoint.
+                instruction_at(2, 0, source.len() as u64),
+                instruction_at(4, 0, source.len() as u64),
+                // The instruction actually generated for line 2.
+                instruction_at(64, line_two_offset, 11),
+            ],
+            sources: BTreeMap::from([(0, "C.sol".to_owned())]),
+            variable_locations: BTreeMap::new(),
+        };
+        let index = TraceSourceIndex {
+            spec: ResolvedContractSpec {
+                address: None,
+                name: "C".to_owned(),
+                debug_dir: PathBuf::from("."),
+            },
+            info,
+            resources: serde_json::Value::Null,
+            functions: Vec::new(),
+            source_contents: BTreeMap::from([(0, source.to_owned())]),
+        };
+
+        let mut trace = TransactionTrace {
+            tx_hash: None,
+            from_addr: "0x1".to_owned(),
+            to_addr: None,
+            value: "0x0".to_owned(),
+            input_data: "0x".to_owned(),
+            gas_used: 0,
+            output: "0x".to_owned(),
+            success: true,
+            error: None,
+            debug_trace_available: true,
+            contract_address: None,
+            backend: None,
+            capabilities: Default::default(),
+            artifacts: Default::default(),
+            steps: Vec::new(),
+        };
+        for pc in [2, 4, 64] {
+            trace.steps.push(soldb_core::TraceStep {
+                pc,
+                op: "JUMPDEST".to_owned(),
+                gas: 0,
+                gas_cost: 0,
+                depth: 0,
+                stack: Vec::new(),
+                memory: None,
+                storage: None,
+                error: None,
+                snapshot: Default::default(),
+            });
+        }
+
+        let target = SourceBreakpointTarget {
+            file: Some("C.sol".to_owned()),
+            line: 2,
+        };
+        let resolved = index
+            .resolve_breakpoint(&target, &trace, 0)
+            .expect("resolve breakpoint");
+
+        assert_eq!(resolved.pc, 64);
+        assert_eq!(resolved.line, 2);
     }
 
     #[test]

--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -1,3 +1,20 @@
+//! The `soldb` command-line interface.
+//!
+//! This binary owns argument parsing, command dispatch, and every piece of
+//! human-readable formatting in the project: the library crates return data and this
+//! layer decides how it looks. That split is what lets the DAP server and the JSON
+//! output reuse the same logic without inheriting terminal behavior.
+//!
+//! Output conventions worth preserving when editing this file:
+//!
+//! - Colors go through the `paint` helpers, which honor `NO_COLOR`, `CLICOLOR_FORCE`,
+//!   and whether stdout is a terminal. Emitting escapes directly breaks the lit tests.
+//! - `--json` and `--json-events` print only their JSON document, so the output stays
+//!   pipeable into `jq`. Progress lines must stay gated on those flags.
+//! - A command that has already rendered a failure returns
+//!   [`soldb_core::SoldbError::AlreadyReported`] so the exit path does not print it
+//!   twice. Failures exit with code 2.
+
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde::Serialize;
 use serde_json::json;

--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -377,10 +377,11 @@ fn main() -> ExitCode {
 
     match result {
         Ok(()) => ExitCode::SUCCESS,
+        // `AlreadyReported` means the command has already rendered the failure, so printing
+        // here would duplicate it.
+        Err(soldb_core::SoldbError::AlreadyReported) => ExitCode::from(2),
         Err(error) => {
-            if !error.to_string().is_empty() {
-                eprintln!("{error}");
-            }
+            eprintln!("{error}");
             ExitCode::from(2)
         }
     }
@@ -613,7 +614,7 @@ fn trace_command(args: &TraceArgs) -> SoldbResult<()> {
                 }))
                 .map_err(|error| soldb_core::SoldbError::Message(error.to_string()))?
             );
-            return Err(soldb_core::SoldbError::Message(String::new()));
+            return Err(soldb_core::SoldbError::AlreadyReported);
         }
         Err(error) => return Err(error),
     };
@@ -651,14 +652,14 @@ fn simulate_command(args: &SimulateArgs) -> SoldbResult<()> {
         Ok(calldata) => calldata,
         Err(error) if args.json => {
             print_json_command_error("SimulationError", &error.to_string(), None)?;
-            return Err(soldb_core::SoldbError::Message(String::new()));
+            return Err(soldb_core::SoldbError::AlreadyReported);
         }
         Err(error) => return Err(error),
     };
     if let Err(message) = validate_simulate_value(&args.value) {
         if args.json {
             print_json_command_error("InvalidValue", &message, Some(&args.value))?;
-            return Err(soldb_core::SoldbError::Message(String::new()));
+            return Err(soldb_core::SoldbError::AlreadyReported);
         }
         return Err(soldb_core::SoldbError::Message(message));
     }
@@ -1191,7 +1192,7 @@ fn list_events_command(args: &ListEventsArgs) -> SoldbResult<()> {
         Ok(logs) => logs,
         Err(error) if args.json_events => {
             print_json_command_error("TransactionReceiptError", &error.to_string(), None)?;
-            return Err(soldb_core::SoldbError::Message(String::new()));
+            return Err(soldb_core::SoldbError::AlreadyReported);
         }
         Err(error) => return Err(error),
     };

--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -29,14 +29,14 @@ use soldb_repl::{
     StepOutcome,
 };
 use soldb_rpc::{RpcLog, TraceBackend};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fmt::Display;
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 static COLORS_ENABLED: OnceLock<bool> = OnceLock::new();
@@ -760,26 +760,23 @@ fn print_simulation_interactive_prelude(
     println!("{} {}", dim("=> contract"), function_color(&contract_name));
     if !args.function_args.is_empty() {
         println!("{}", info("Parameters:"));
-        let params = resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-            .ok()
-            .and_then(|specs| {
-                specs
-                    .into_iter()
-                    .find_map(|spec| call_descriptor_for_calldata(&spec, calldata))
-            })
-            .map(|descriptor| descriptor.params)
-            .unwrap_or_else(|| {
-                args.function_args
-                    .iter()
-                    .enumerate()
-                    .map(|(index, value)| DecodedCallParam {
-                        name: format!("arg{index}"),
-                        ty: None,
-                        value: value.clone(),
-                        raw: false,
-                    })
-                    .collect()
-            });
+        let params =
+            resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref())
+                .into_iter()
+                .find_map(|spec| call_descriptor_for_calldata(&spec, calldata))
+                .map(|descriptor| descriptor.params)
+                .unwrap_or_else(|| {
+                    args.function_args
+                        .iter()
+                        .enumerate()
+                        .map(|(index, value)| DecodedCallParam {
+                            name: format!("arg{index}"),
+                            ty: None,
+                            value: value.clone(),
+                            raw: false,
+                        })
+                        .collect()
+                });
         for param in params {
             println!(
                 "{} {}",
@@ -796,7 +793,7 @@ fn interactive_trace_source_index(
 ) -> Option<TraceSourceIndex> {
     let contract_address = trace.to_addr.as_ref().or(trace.contract_address.as_ref());
     source_index_for_specs(
-        resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref()).ok()?,
+        resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref()),
         contract_address.map(String::as_str),
     )
 }
@@ -806,7 +803,7 @@ fn interactive_simulation_source_index(
     contract_address: &str,
 ) -> Option<TraceSourceIndex> {
     source_index_for_specs(
-        resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref()).ok()?,
+        resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref()),
         Some(contract_address),
     )
 }
@@ -823,15 +820,13 @@ fn source_index_for_specs(
                     .as_deref()
                     .is_some_and(|address| address.eq_ignore_ascii_case(contract_address))
             })
-            .find_map(|spec| TraceSourceIndex::load(spec).ok())
+            .find_map(load_source_index)
         {
             return Some(index);
         }
     }
 
-    specs
-        .iter()
-        .find_map(|spec| TraceSourceIndex::load(spec).ok())
+    specs.iter().find_map(load_source_index)
 }
 
 fn run_interactive_debugger(
@@ -1973,7 +1968,7 @@ fn build_trace_call_frames(
     spec: &ResolvedContractSpec,
     fallback: Option<CallDescriptor>,
 ) -> Vec<CallFrame> {
-    let source_index = TraceSourceIndex::load(spec).ok();
+    let source_index = load_source_index(spec);
     let descriptor = source_index
         .as_ref()
         .and_then(|index| index.descriptor_for_calldata(&trace.input_data))
@@ -1988,24 +1983,17 @@ fn build_simulation_call_frames(
     raw_data: &str,
     fallback: Option<CallDescriptor>,
 ) -> Vec<CallFrame> {
-    let source_index = resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-        .ok()
-        .and_then(|specs| {
-            specs
-                .into_iter()
-                .find_map(|spec| TraceSourceIndex::load(&spec).ok())
-        });
+    let source_index =
+        resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref())
+            .into_iter()
+            .find_map(|spec| load_source_index(&spec));
     let descriptor = source_index
         .as_ref()
         .and_then(|index| index.descriptor_for_calldata(raw_data))
         .or_else(|| {
-            resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-                .ok()
-                .and_then(|specs| {
-                    specs
-                        .into_iter()
-                        .find_map(|spec| abi_descriptor_for_calldata(&spec, raw_data))
-                })
+            resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref())
+                .into_iter()
+                .find_map(|spec| abi_descriptor_for_calldata(&spec, raw_data))
         })
         .or(fallback);
     build_call_frames(trace, source_index.as_ref(), descriptor)
@@ -2071,8 +2059,7 @@ fn call_descriptor_for_calldata(
     spec: &ResolvedContractSpec,
     calldata: &str,
 ) -> Option<CallDescriptor> {
-    TraceSourceIndex::load(spec)
-        .ok()
+    load_source_index(spec)
         .and_then(|index| index.descriptor_for_calldata(calldata))
         .or_else(|| abi_descriptor_for_calldata(spec, calldata))
 }
@@ -2115,13 +2102,9 @@ fn simulated_call_descriptor(
         });
     }
 
-    resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-        .ok()
-        .and_then(|specs| {
-            specs
-                .into_iter()
-                .find_map(|spec| call_descriptor_for_calldata(&spec, raw_data))
-        })
+    resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref())
+        .into_iter()
+        .find_map(|spec| call_descriptor_for_calldata(&spec, raw_data))
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -2780,15 +2763,32 @@ fn load_event_registry(args: &ListEventsArgs) -> SoldbResult<EventRegistry> {
 }
 
 fn trace_event_registry(args: &TraceArgs) -> EventRegistry {
-    resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-        .and_then(event_registry_for_specs)
-        .unwrap_or_default()
+    event_registry_reporting(resolve_contract_specs_reporting(
+        &args.ethdebug_dir,
+        args.contracts.as_deref(),
+    ))
 }
 
 fn simulate_event_registry(args: &SimulateArgs) -> EventRegistry {
-    resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-        .and_then(event_registry_for_specs)
-        .unwrap_or_default()
+    event_registry_reporting(resolve_contract_specs_reporting(
+        &args.ethdebug_dir,
+        args.contracts.as_deref(),
+    ))
+}
+
+/// Builds the event registry, reporting a failure instead of decoding nothing in silence.
+fn event_registry_reporting(specs: Vec<ResolvedContractSpec>) -> EventRegistry {
+    match event_registry_for_specs(specs) {
+        Ok(registry) => registry,
+        Err(error) => {
+            report_once(
+                format!("events:{error}"),
+                &format!("could not load event ABIs: {error}"),
+                "logs are shown without decoded names or arguments",
+            );
+            EventRegistry::default()
+        }
+    }
 }
 
 fn event_registry_for_specs(specs: Vec<ResolvedContractSpec>) -> SoldbResult<EventRegistry> {
@@ -2825,6 +2825,71 @@ struct ResolvedContractSpec {
     address: Option<String>,
     name: String,
     debug_dir: PathBuf,
+}
+
+/// Loads ETHDebug metadata for a contract spec, reporting a failure instead of hiding it.
+///
+/// The user asked for ETHDebug by naming a directory on the command line. Silently
+/// dropping to a raw opcode view when that directory cannot be read is the worst failure
+/// mode for a debugger whose whole premise is compiler-generated debug info: the symptom
+/// (no source lines) looks identical to a contract that was simply compiled without it.
+///
+/// Reports go to stderr so `--json` output stays pipeable, and each spec is reported only
+/// once because a single run resolves the same spec from several places.
+fn load_source_index(spec: &ResolvedContractSpec) -> Option<TraceSourceIndex> {
+    match TraceSourceIndex::load(spec) {
+        Ok(index) => Some(index),
+        Err(error) => {
+            report_once(
+                format!("ethdebug:{}:{}", spec.name, spec.debug_dir.display()),
+                &format!(
+                    "could not load ETHDebug metadata for `{}` from `{}`: {error}",
+                    spec.name,
+                    spec.debug_dir.display()
+                ),
+                "source lines, variables, and decoded parameters are unavailable for it",
+            );
+            None
+        }
+    }
+}
+
+/// Resolves contract specs, reporting a bad spec instead of continuing with none.
+///
+/// Every caller degrades to "no debug info" on failure, so without this a typo in
+/// `--ethdebug-dir` is indistinguishable from not passing it at all.
+fn resolve_contract_specs_reporting(
+    ethdebug_dirs: &[String],
+    contracts_file: Option<&str>,
+) -> Vec<ResolvedContractSpec> {
+    match resolve_contract_specs(ethdebug_dirs, contracts_file) {
+        Ok(specs) => specs,
+        Err(error) => {
+            report_once(
+                format!("specs:{error}"),
+                &format!("could not resolve the requested contracts: {error}"),
+                "continuing without source-level information for this run",
+            );
+            Vec::new()
+        }
+    }
+}
+
+/// Writes a warning and a follow-up note to stderr, at most once per `key`.
+fn report_once(key: String, message: &str, note: &str) {
+    static REPORTED: OnceLock<Mutex<BTreeSet<String>>> = OnceLock::new();
+
+    let mut reported = match REPORTED.get_or_init(|| Mutex::new(BTreeSet::new())).lock() {
+        Ok(reported) => reported,
+        // A poisoned lock only means another thread panicked while reporting. Losing
+        // deduplication is better than losing the diagnostic.
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if !reported.insert(key) {
+        return;
+    }
+    eprintln!("{} {message}", warning("warning:"));
+    eprintln!("{} {note}", dim("note:"));
 }
 
 fn resolve_contract_specs(
@@ -2875,6 +2940,17 @@ fn resolve_ethdebug_spec(spec_text: &str) -> SoldbResult<Vec<ResolvedContractSpe
                 debug_dir: path,
             }]);
         }
+    }
+
+    // Resolving nothing is a failure, not an empty result. The user named this on the
+    // command line; returning zero contracts silently is indistinguishable from having
+    // passed no `--ethdebug-dir` at all, and it is how a mistyped spec turns into a
+    // confusing "no debug info" trace.
+    if loaded.is_empty() {
+        return Err(soldb_core::SoldbError::Message(format!(
+            "no contracts found for `{spec_text}`; expected `<address>:<contract>:<dir>`, \
+             a directory of ETHDebug artifacts, or a contract mapping file"
+        )));
     }
 
     Ok(loaded)
@@ -3081,8 +3157,7 @@ fn trace_web_contracts(
     args: &TraceArgs,
     trace: &TransactionTrace,
 ) -> BTreeMap<String, soldb_serializer::WebContractMetadata> {
-    let specs =
-        resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref()).unwrap_or_default();
+    let specs = resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref());
     web_contracts_for_specs(specs, trace, None)
 }
 
@@ -3091,8 +3166,7 @@ fn simulate_web_contracts(
     trace: &TransactionTrace,
     contract_address: &str,
 ) -> BTreeMap<String, soldb_serializer::WebContractMetadata> {
-    let specs =
-        resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref()).unwrap_or_default();
+    let specs = resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref());
     web_contracts_for_specs(specs, trace, Some(contract_address))
 }
 
@@ -3132,7 +3206,7 @@ fn web_contracts_for_specs(
 fn web_contract_metadata_for_spec(
     spec: &ResolvedContractSpec,
 ) -> Option<soldb_serializer::WebContractMetadata> {
-    let source_index = TraceSourceIndex::load(spec).ok();
+    let source_index = load_source_index(spec);
     let mut pc_to_source_mappings = BTreeMap::new();
     let mut source_paths = BTreeMap::new();
     let mut sources = BTreeMap::new();
@@ -3177,15 +3251,13 @@ fn normalize_contract_address_key(address: &str) -> String {
 }
 
 fn trace_contract_name(args: &TraceArgs) -> Option<String> {
-    resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-        .ok()
-        .and_then(|specs| specs.into_iter().next().map(|spec| spec.name))
+    trace_contract_spec(args).map(|spec| spec.name)
 }
 
 fn trace_contract_spec(args: &TraceArgs) -> Option<ResolvedContractSpec> {
-    resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-        .ok()
-        .and_then(|specs| specs.into_iter().next())
+    resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref())
+        .into_iter()
+        .next()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -3240,9 +3312,10 @@ fn trace_debug_metadata(spec: &ResolvedContractSpec) -> TraceDebugMetadata {
 }
 
 fn simulate_contract_name(args: &SimulateArgs) -> Option<String> {
-    resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-        .ok()
-        .and_then(|specs| specs.into_iter().next().map(|spec| spec.name))
+    resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref())
+        .into_iter()
+        .next()
+        .map(|spec| spec.name)
 }
 
 fn simulate_calldata(args: &SimulateArgs) -> SoldbResult<String> {
@@ -3342,8 +3415,7 @@ fn format_simulated_call(args: &SimulateArgs, function_name: &str) -> String {
 }
 
 fn simulation_source_file(args: &SimulateArgs, contract_name: &str) -> Option<String> {
-    resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-        .ok()?
+    resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref())
         .into_iter()
         .find(|spec| spec.name == contract_name)
         .and_then(|spec| {
@@ -3377,13 +3449,9 @@ fn simulate_display_function_name(args: &SimulateArgs, calldata: &str) -> String
         return signature.clone();
     }
 
-    resolve_contract_specs(&args.ethdebug_dir, args.contracts.as_deref())
-        .ok()
-        .and_then(|specs| {
-            specs
-                .into_iter()
-                .find_map(|spec| call_descriptor_for_calldata(&spec, calldata))
-        })
+    resolve_contract_specs_reporting(&args.ethdebug_dir, args.contracts.as_deref())
+        .into_iter()
+        .find_map(|spec| call_descriptor_for_calldata(&spec, calldata))
         .map_or_else(|| "raw_data".to_owned(), |descriptor| descriptor.name)
 }
 

--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -908,6 +908,17 @@ fn run_interactive_debugger(
                     println!("{} {}", warning("Could not print resources:"), error);
                 }
             }
+            DebuggerCommand::Vars => {
+                print_debugger_variables(&state, source_index.as_ref(), None);
+            }
+            DebuggerCommand::Print(name) => {
+                let name = name.trim();
+                if name.is_empty() {
+                    println!("{} print <variable>", warning("Usage:"));
+                } else {
+                    print_debugger_variables(&state, source_index.as_ref(), Some(name));
+                }
+            }
             DebuggerCommand::Unknown(command) => {
                 println!("{} {}", warning("Unknown command:"), command);
             }
@@ -1172,15 +1183,90 @@ fn print_step_outcome(
     }
 }
 
+/// Prints the source variables ETHDebug reports as live at the current program counter.
+///
+/// With `filter` set, only the variable of that name is printed. This is the terminal
+/// counterpart of the DAP `variables` request; both go through
+/// `soldb_debugger::variables_for_step` so the two frontends decode identically.
+fn print_debugger_variables(
+    state: &DebuggerState,
+    source_index: Option<&TraceSourceIndex>,
+    filter: Option<&str>,
+) {
+    let Some(index) = source_index else {
+        println!(
+            "{} no ETHDebug metadata is loaded; start the session with `--ethdebug-dir <address>:<contract>:<dir>`",
+            warning("Cannot read variables:")
+        );
+        return;
+    };
+    let Some(trace) = state.trace() else {
+        println!("{} no trace is loaded", warning("Cannot read variables:"));
+        return;
+    };
+    let Some(step) = state.current_step_data() else {
+        println!(
+            "{} step {} is outside the loaded trace",
+            warning("Cannot read variables:"),
+            state.current_step
+        );
+        return;
+    };
+
+    let variables = soldb_debugger::variables_for_step(trace, &index.info, step);
+    let selected = variables
+        .iter()
+        .filter(|variable| filter.is_none_or(|name| variable.name == name))
+        .collect::<Vec<_>>();
+
+    if selected.is_empty() {
+        match filter {
+            Some(name) => println!(
+                "{} `{name}` is not in scope at PC {}",
+                warning("No such variable:"),
+                number_color(step.pc)
+            ),
+            None => println!(
+                "{} no variables in scope at PC {}",
+                dim("Variables:"),
+                number_color(step.pc)
+            ),
+        }
+        return;
+    }
+
+    for variable in selected {
+        let value = match variable.value.status {
+            soldb_debugger::DebugValueStatus::Unavailable => warning(&variable.value.display),
+            _ => success(&variable.value.display),
+        };
+        println!(
+            "{} {} = {} {}",
+            info(&variable.ty),
+            bold(&variable.name),
+            value,
+            dim(format!(
+                "[{}+{}]",
+                variable.location.kind, variable.location.offset
+            ))
+        );
+    }
+}
+
 fn print_debugger_help(topic: Option<&str>) {
     match topic {
         Some("mode") => println!("mode source|asm - switch display mode"),
         Some("info") => println!("info resources [--json] - print loaded ETHDebug resources"),
+        Some("vars" | "locals" | "print") => {
+            println!("vars - print every source variable live at the current PC");
+            println!("print <variable> - print one source variable by name");
+        }
         Some(topic) => println!("No help for {topic}"),
         None => {
             println!("Commands: next, nexti, step, continue, goto <step>");
             println!("          break <pc>|<file>:<line>|line <line>");
             println!("          clear <pc>|<file>:<line>|line <line>");
+            println!("          vars, print <variable>");
             println!("          info resources [--json]");
             println!("          mode source|asm, help, quit");
         }

--- a/crates/soldb-compiler/src/lib.rs
+++ b/crates/soldb-compiler/src/lib.rs
@@ -1,3 +1,17 @@
+//! Driving `solc` and discovering the ETHDebug artifacts it produces.
+//!
+//! This crate compiles Solidity with debug info enabled, locates the resulting
+//! artifacts, and provides the deploy helpers behind local auto-deploy workflows.
+//!
+//! ETHDebug's command-line surface has changed across compiler releases: older versions
+//! accept `--ethdebug`/`--ethdebug-runtime`, while newer ones expose the same output
+//! through `--experimental --ethdebug-program`/`--ethdebug-program-runtime`/
+//! `--ethdebug-resources`. [`CompilerConfig::compile_with_ethdebug`] probes for that by
+//! trying the configured flags and falling back only when the compiler rejects them as
+//! unrecognised, so a single code path works across versions without a hardcoded cutoff.
+//! Artifact discovery is version-tolerant for the same reason and accepts either the
+//! `ethdebug.json` or the `ethdebug_resources.json` spelling of the resources file.
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/soldb-compiler/src/lib.rs
+++ b/crates/soldb-compiler/src/lib.rs
@@ -522,7 +522,12 @@ fn extract_solc_version(output: &str) -> Option<String> {
 }
 
 fn version_supports_ethdebug(version: &str) -> bool {
-    let parts = version
+    // Development builds report a prerelease suffix, for example
+    // `0.8.37-develop.2026.8.22`. Only the leading `major.minor.patch` is the version;
+    // parsing `37-develop` as a component fails and would reject the compiler outright —
+    // and a development build is exactly where new ETHDebug output appears first.
+    let core = version.split(['-', '+']).next().unwrap_or(version);
+    let parts = core
         .split('.')
         .map(str::parse::<u64>)
         .collect::<Result<Vec<_>, _>>();
@@ -679,7 +684,9 @@ mod tests {
     use std::net::{TcpListener, TcpStream};
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{auto_deploy, dual_compile, AutoDeployConfig, CompilerConfig};
+    use super::{
+        auto_deploy, dual_compile, version_supports_ethdebug, AutoDeployConfig, CompilerConfig,
+    };
     use serde_json::json;
 
     #[test]
@@ -729,6 +736,37 @@ mod tests {
         assert!(new_info.supported);
         assert!(!old_info.supported);
         assert_eq!(old_info.version.as_deref(), Some("0.8.28"));
+    }
+
+    #[test]
+    fn accepts_prerelease_solc_versions() {
+        // Development builds of the compiler report a prerelease suffix. They are where new
+        // ETHDebug output lands first, so the version gate has to read past the suffix
+        // rather than treat `37-develop` as a version component.
+        assert!(version_supports_ethdebug("0.8.37-develop.2026.8.22"));
+        assert!(version_supports_ethdebug("0.8.29-nightly.2025.4.1"));
+        assert!(version_supports_ethdebug("0.9.0-develop"));
+        assert!(!version_supports_ethdebug("0.8.28-develop.2025.1.1"));
+        assert!(!version_supports_ethdebug("not-a-version"));
+
+        // Release versions keep working unchanged.
+        assert!(version_supports_ethdebug("0.8.31"));
+        assert!(!version_supports_ethdebug("0.8.16"));
+    }
+
+    #[test]
+    fn reports_the_full_prerelease_version_string() {
+        let temp = temp_dir("prerelease-version");
+        let solc = fake_solc(&temp, "0.8.37-develop.2026.8.22", false);
+
+        let info = CompilerConfig {
+            solc_path: solc.to_string_lossy().into_owned(),
+            ..CompilerConfig::default()
+        }
+        .verify_solc_version();
+
+        assert!(info.supported, "develop builds support ETHDebug");
+        assert_eq!(info.version.as_deref(), Some("0.8.37-develop.2026.8.22"));
     }
 
     #[test]

--- a/crates/soldb-core/src/lib.rs
+++ b/crates/soldb-core/src/lib.rs
@@ -50,16 +50,68 @@ pub struct TraceStep {
 }
 
 impl TraceStep {
+    /// Borrows the machine state this step captured, without copying it.
+    ///
+    /// A step records the same data twice: the flat `stack`/`memory`/`storage` fields, and
+    /// a [`StepSnapshot`] that additionally carries the storage diff. Whichever is
+    /// populated, this returns a view of it.
+    ///
+    /// Prefer this over [`TraceStep::normalized_snapshot`] anywhere that walks a trace.
+    /// Traces routinely run to hundreds of thousands of steps and each one's `memory` can
+    /// be tens of kilobytes, so copying per step — or, as variable decoding does, per
+    /// variable per step — dominates the cost of reading a trace.
+    #[must_use]
+    pub fn snapshot_ref(&self) -> StepSnapshotRef<'_> {
+        static EMPTY_STORAGE: BTreeMap<String, String> = BTreeMap::new();
+        static EMPTY_STORAGE_DIFF: BTreeMap<String, StorageChange> = BTreeMap::new();
+
+        if !self.snapshot.is_empty() {
+            return StepSnapshotRef {
+                stack: &self.snapshot.stack,
+                memory: self.snapshot.memory.as_deref(),
+                storage: &self.snapshot.storage,
+                storage_diff: &self.snapshot.storage_diff,
+            };
+        }
+        StepSnapshotRef {
+            stack: &self.stack,
+            memory: self.memory.as_deref(),
+            storage: self.storage.as_ref().unwrap_or(&EMPTY_STORAGE),
+            storage_diff: &EMPTY_STORAGE_DIFF,
+        }
+    }
+
+    /// Copies the machine state this step captured into an owned [`StepSnapshot`].
+    ///
+    /// Use this only when ownership is genuinely required; [`TraceStep::snapshot_ref`] is
+    /// the same view without the copy.
     #[must_use]
     pub fn normalized_snapshot(&self) -> StepSnapshot {
-        if !self.snapshot.is_empty() {
-            return self.snapshot.clone();
-        }
+        self.snapshot_ref().to_owned_snapshot()
+    }
+}
+
+/// A borrowed view of one step's captured machine state.
+///
+/// Serializes identically to [`StepSnapshot`], so it can stand in wherever a snapshot is
+/// written out. Produced by [`TraceStep::snapshot_ref`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct StepSnapshotRef<'a> {
+    pub stack: &'a [String],
+    pub memory: Option<&'a str>,
+    pub storage: &'a BTreeMap<String, String>,
+    pub storage_diff: &'a BTreeMap<String, StorageChange>,
+}
+
+impl StepSnapshotRef<'_> {
+    /// Copies this view into an owned [`StepSnapshot`].
+    #[must_use]
+    pub fn to_owned_snapshot(&self) -> StepSnapshot {
         StepSnapshot {
-            stack: self.stack.clone(),
-            memory: self.memory.clone(),
-            storage: self.storage.clone().unwrap_or_default(),
-            storage_diff: BTreeMap::new(),
+            stack: self.stack.to_vec(),
+            memory: self.memory.map(str::to_owned),
+            storage: self.storage.clone(),
+            storage_diff: self.storage_diff.clone(),
         }
     }
 }
@@ -246,10 +298,69 @@ pub struct FunctionCall {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::{
         FunctionCall, StepSnapshot, StorageChange, TraceArtifacts, TraceCapabilities, TraceStep,
         TransactionTrace,
     };
+
+    fn step_with(snapshot: StepSnapshot) -> TraceStep {
+        TraceStep {
+            pc: 3,
+            op: "SSTORE".to_owned(),
+            gas: 100,
+            gas_cost: 5,
+            depth: 1,
+            stack: vec!["0x01".to_owned(), "0x02".to_owned()],
+            memory: Some("aabb".to_owned()),
+            storage: Some(BTreeMap::from([("0x00".to_owned(), "0x2a".to_owned())])),
+            error: None,
+            snapshot,
+        }
+    }
+
+    #[test]
+    fn borrowed_snapshot_matches_the_owned_one() {
+        // `snapshot_ref` is what every trace walk uses, so it has to be indistinguishable
+        // from `normalized_snapshot` in both shapes a step can take: snapshot populated,
+        // and only the flat fields populated. The serialized forms must match too, because
+        // the web JSON document writes a snapshot per step.
+        let flat = step_with(StepSnapshot::default());
+        let populated = step_with(StepSnapshot {
+            stack: vec!["0x09".to_owned()],
+            memory: Some("ccdd".to_owned()),
+            storage: BTreeMap::from([("0x01".to_owned(), "0x63".to_owned())]),
+            storage_diff: BTreeMap::from([(
+                "0x01".to_owned(),
+                StorageChange {
+                    before: None,
+                    after: Some("0x63".to_owned()),
+                },
+            )]),
+        });
+
+        for step in [&flat, &populated] {
+            assert_eq!(
+                step.snapshot_ref().to_owned_snapshot(),
+                step.normalized_snapshot()
+            );
+            assert_eq!(
+                serde_json::to_string(&step.snapshot_ref()).expect("borrowed snapshot"),
+                serde_json::to_string(&step.normalized_snapshot()).expect("owned snapshot"),
+            );
+        }
+
+        // The flat shape falls back to the top-level fields and reports no storage diff.
+        assert_eq!(flat.snapshot_ref().stack, ["0x01", "0x02"]);
+        assert_eq!(flat.snapshot_ref().memory, Some("aabb"));
+        assert!(flat.snapshot_ref().storage_diff.is_empty());
+
+        // A populated snapshot wins over the flat fields.
+        assert_eq!(populated.snapshot_ref().stack, ["0x09"]);
+        assert_eq!(populated.snapshot_ref().memory, Some("ccdd"));
+        assert_eq!(populated.snapshot_ref().storage_diff.len(), 1);
+    }
 
     #[test]
     fn core_models_are_serializable() {

--- a/crates/soldb-core/src/lib.rs
+++ b/crates/soldb-core/src/lib.rs
@@ -1,3 +1,18 @@
+//! Shared vocabulary types for the SolDB workspace.
+//!
+//! Every other crate agrees on the types defined here: [`TransactionTrace`] and its
+//! [`TraceStep`]s are what an execution backend produces and what the debugger, the
+//! serializer, and the frontends consume. This crate deliberately has no soldb
+//! dependencies so that it can stay the single type boundary in the graph.
+//!
+//! These types are also a serialization contract. They round-trip through `serde` into
+//! trace files and into the web-facing JSON document, so adding a field is additive and
+//! needs `#[serde(default)]`, while renaming or removing one is a breaking change.
+//!
+//! [`TraceCapabilities`] describes what the selected backend was actually able to
+//! record. Frontends should branch on those flags rather than on the backend name, so a
+//! new backend does not require changes further up the stack.
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};

--- a/crates/soldb-core/src/lib.rs
+++ b/crates/soldb-core/src/lib.rs
@@ -20,8 +20,16 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum SoldbError {
+    /// A failure described by a human-readable message.
     #[error("{0}")]
     Message(String),
+    /// The failure was already rendered for the user, typically as a JSON error document
+    /// on a `--json` code path. Callers must exit non-zero without printing anything else.
+    ///
+    /// This exists so the exit path never has to inspect error *text* to decide whether a
+    /// message was already shown.
+    #[error("")]
+    AlreadyReported,
 }
 
 pub type SoldbResult<T> = Result<T, SoldbError>;

--- a/crates/soldb-dap/src/lib.rs
+++ b/crates/soldb-dap/src/lib.rs
@@ -1,3 +1,14 @@
+//! Debug Adapter Protocol support for editor integrations.
+//!
+//! This crate contains the DAP wire layer — `Content-Length` framing, request and
+//! response bodies — and, in [`server`], the adapter that maps DAP requests onto a
+//! SolDB debug session: breakpoints, stack frames, scopes, variables, and stepping.
+//!
+//! A session is launched from a trace file, an inline trace, or a transaction hash plus
+//! an RPC URL. Source mapping and variable decoding come from `soldb-ethdebug` and
+//! `soldb-debugger`, the same path the terminal debugger uses, so an editor and the CLI
+//! report the same values.
+
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 

--- a/crates/soldb-dap/src/server.rs
+++ b/crates/soldb-dap/src/server.rs
@@ -368,7 +368,7 @@ impl DapServer {
         let Some(step) = self.debugger.current_step_data() else {
             return Vec::new();
         };
-        step.normalized_snapshot()
+        step.snapshot_ref()
             .stack
             .iter()
             .enumerate()
@@ -382,7 +382,7 @@ impl DapServer {
         let Some(step) = self.debugger.current_step_data() else {
             return Vec::new();
         };
-        let Some(memory) = step.normalized_snapshot().memory else {
+        let Some(memory) = step.snapshot_ref().memory else {
             return Vec::new();
         };
         if memory.is_empty() {
@@ -406,7 +406,7 @@ impl DapServer {
         let Some(step) = self.debugger.current_step_data() else {
             return Vec::new();
         };
-        let snapshot = step.normalized_snapshot();
+        let snapshot = step.snapshot_ref();
         let mut variables = snapshot
             .storage
             .iter()
@@ -456,14 +456,14 @@ impl DapServer {
                     .parse::<usize>()
                     .ok();
                 index
-                    .and_then(|index| step.normalized_snapshot().stack.get(index).cloned())
+                    .and_then(|index| step.snapshot_ref().stack.get(index).cloned())
                     .unwrap_or_else(|| "<unavailable>".to_owned())
             }
             expression if expression.starts_with("storage[") && expression.ends_with(']') => {
                 let slot = expression
                     .trim_start_matches("storage[")
                     .trim_end_matches(']');
-                step.normalized_snapshot()
+                step.snapshot_ref()
                     .storage
                     .get(slot)
                     .cloned()

--- a/crates/soldb-dap/src/server.rs
+++ b/crates/soldb-dap/src/server.rs
@@ -1,3 +1,12 @@
+//! The Debug Adapter Protocol server.
+//!
+//! [`DapServer`] holds one debug session and maps DAP requests onto it: launching from a
+//! trace file, an inline trace, or a transaction hash plus RPC URL; setting breakpoints;
+//! reporting stack frames, scopes, and variables; and stepping.
+//!
+//! Source mapping and variable decoding go through `soldb-ethdebug` and `soldb-debugger`
+//! so an editor reports the same values as the terminal debugger.
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::{Read, Write};

--- a/crates/soldb-debugger/src/lib.rs
+++ b/crates/soldb-debugger/src/lib.rs
@@ -245,15 +245,15 @@ fn raw_value_for_location(
     step: &TraceStep,
     variable: &VariableLocation,
 ) -> Option<String> {
-    let snapshot = step.normalized_snapshot();
+    let snapshot = step.snapshot_ref();
     match variable.location_type.as_str() {
         "stack" => snapshot
             .stack
             .get(variable.offset as usize)
             .map(|value| normalize_hex(value)),
-        "memory" => word_from_hex_bytes(snapshot.memory.as_deref()?, variable.offset as usize),
+        "memory" => word_from_hex_bytes(snapshot.memory?, variable.offset as usize),
         "calldata" => word_from_hex_bytes(&trace.input_data, variable.offset as usize),
-        "storage" => storage_value(&snapshot.storage, variable.offset),
+        "storage" => storage_value(snapshot.storage, variable.offset),
         _ => None,
     }
 }

--- a/crates/soldb-debugger/src/lib.rs
+++ b/crates/soldb-debugger/src/lib.rs
@@ -1,3 +1,18 @@
+//! Source-level debugging over an execution trace.
+//!
+//! Given a [`soldb_core::TransactionTrace`] and the ETHDebug metadata for the contract
+//! it executed, this crate answers the questions a source-level debugger asks: which
+//! source span a step is at, which function contains a program counter, and which
+//! variables are live there with what values.
+//!
+//! It is frontend-agnostic on purpose. [`variables_for_step`] is what backs both the CLI
+//! REPL's `vars`/`print` commands and the DAP server's variables view, so the terminal
+//! and the editor decode identically.
+//!
+//! Variable values are only as good as the debug info: a location the backend did not
+//! capture decodes to [`DebugValueStatus::Unavailable`], and a value whose declared type
+//! is not decodable is reported as [`DebugValueStatus::Raw`] rather than guessed at.
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};

--- a/crates/soldb-debugger/src/lib.rs
+++ b/crates/soldb-debugger/src/lib.rs
@@ -116,7 +116,7 @@ impl DebugSession {
                     && function.declaration_start <= location.offset
                     && location.offset <= function.body_end
             })
-            .min_by_key(|function| function.body_end - function.declaration_start)
+            .min_by_key(|function| function.body_end.saturating_sub(function.declaration_start))
     }
 
     #[must_use]

--- a/crates/soldb-ethdebug/src/abi.rs
+++ b/crates/soldb-ethdebug/src/abi.rs
@@ -1,3 +1,12 @@
+//! ABI encoding and function-signature parsing.
+//!
+//! This module turns a human-written signature such as `submitPerson((string,uint256))`
+//! plus its arguments into calldata, and derives the four-byte selector for it. Tuples,
+//! fixed and dynamic arrays, and the elementary value types are supported.
+//!
+//! It also carries the keccak-256 implementation used for selectors and event topics, so
+//! the workspace does not take a hashing dependency for this one purpose.
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use soldb_core::{SoldbError, SoldbResult};

--- a/crates/soldb-ethdebug/src/abi.rs
+++ b/crates/soldb-ethdebug/src/abi.rs
@@ -164,14 +164,13 @@ pub fn function_selector(signature: &str) -> SoldbResult<[u8; 4]> {
 pub fn keccak256(input: &[u8]) -> [u8; 32] {
     const RATE: usize = 136;
     let mut state = [0_u64; 25];
-    let mut chunks = input.chunks_exact(RATE);
+    let (blocks, remainder) = input.as_chunks::<RATE>();
 
-    for block in &mut chunks {
+    for block in blocks {
         absorb_block(&mut state, block);
         keccak_f1600(&mut state);
     }
 
-    let remainder = chunks.remainder();
     let mut final_block = [0_u8; RATE];
     final_block[..remainder.len()].copy_from_slice(remainder);
     final_block[remainder.len()] ^= 0x01;
@@ -603,8 +602,8 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
 }
 
 fn absorb_block(state: &mut [u64; 25], block: &[u8]) {
-    for (lane, chunk) in block.chunks_exact(8).enumerate() {
-        state[lane] ^= u64::from_le_bytes(chunk.try_into().expect("8-byte lane"));
+    for (lane, chunk) in block.as_chunks::<8>().0.iter().enumerate() {
+        state[lane] ^= u64::from_le_bytes(*chunk);
     }
 }
 
@@ -770,6 +769,48 @@ mod tests {
                 .as_ref()),
             "7cf5dab0"
         );
+    }
+
+    #[test]
+    fn hashes_inputs_spanning_the_keccak_rate() {
+        // The absorb loop consumes 136-byte blocks, so the cases that matter sit either
+        // side of that boundary. Nothing else here reaches it: the existing vectors are a
+        // few dozen bytes at most, which leaves the multi-block path untested.
+        // Expected digests come from `cast keccak`.
+        fn pattern(len: usize) -> Vec<u8> {
+            (0..len)
+                .map(|index| u8::try_from((index * 7 + 3) % 256).expect("value fits a byte"))
+                .collect()
+        }
+
+        for (len, expected) in [
+            (
+                135,
+                "00ef96af9cf4b24c7f269d922294444a197d0a33638c2e56634c57e892103a8f",
+            ),
+            (
+                136,
+                "742061bcad767ed4c4f5883b1dcb1aad11afdcc140dc469d953759b127b9f9ed",
+            ),
+            (
+                137,
+                "e3371f61e770abf254c34239c3b0099ad90594507415bc81dd0a10b9692bbf2a",
+            ),
+            (
+                272,
+                "ac141fd7b0a0ffcd2e967254d508da3ec616596493c36fa304425647d90e6de5",
+            ),
+            (
+                300,
+                "fa75f2293be9f9a14dcdeeff53f7b91ff6a2b1331b13886e69077ab1cf8252a9",
+            ),
+        ] {
+            assert_eq!(
+                hex(keccak256(&pattern(len)).as_ref()),
+                expected,
+                "len {len}"
+            );
+        }
     }
 
     #[test]

--- a/crates/soldb-ethdebug/src/events.rs
+++ b/crates/soldb-ethdebug/src/events.rs
@@ -246,7 +246,8 @@ fn decode_param_at(
 ) -> SoldbResult<Value> {
     if event_param_is_dynamic(input)? {
         let relative_offset = read_usize_word(data, head_offset, &input.name)?;
-        return decode_dynamic_param(input, data, base_offset + relative_offset);
+        let offset = checked_offset(base_offset, relative_offset, &input.name)?;
+        return decode_dynamic_param(input, data, offset);
     }
     decode_static_param(input, data, head_offset)
 }
@@ -273,7 +274,8 @@ fn decode_dynamic_param(input: &EventParam, data: &[u8], offset: usize) -> Soldb
             (len, offset, offset)
         } else {
             let len = read_usize_word(data, offset, &input.name)?;
-            (len, offset + 32, offset + 32)
+            let heads_offset = checked_offset(offset, 32, &input.name)?;
+            (len, heads_offset, heads_offset)
         };
         return decode_array_items(&base, len, data, heads_offset, offsets_base);
     }
@@ -312,7 +314,7 @@ fn decode_tuple_components(
     for component in components {
         let head_words = event_param_head_words(component)?;
         values.push(decode_param_at(component, data, offset, tuple_offset)?);
-        offset += head_words * 32;
+        offset = advance_offset(offset, head_words, &component.name)?;
     }
     Ok(Value::Array(values))
 }
@@ -324,12 +326,34 @@ fn decode_array_items(
     heads_offset: usize,
     offsets_base: usize,
 ) -> SoldbResult<Value> {
+    let base_head_words = event_param_head_words(base)?;
+    // `len` is read from the event payload for dynamic arrays, so it is untrusted. Every
+    // element occupies at least its head words inside `data`; reject a length that cannot
+    // possibly fit before reserving anything, otherwise a hostile log reserves gigabytes.
+    let element_head = base_head_words
+        .checked_mul(32)
+        .filter(|size| *size > 0)
+        .ok_or_else(|| {
+            SoldbError::Message(format!(
+                "Event array element '{}' has no decodable width",
+                base.ty
+            ))
+        })?;
+    let available = data.len().saturating_sub(heads_offset);
+    if element_head
+        .checked_mul(len)
+        .is_none_or(|required| required > available)
+    {
+        return Err(SoldbError::Message(format!(
+            "Event array length {len} exceeds the {available} bytes of remaining event data"
+        )));
+    }
+
     let mut offset = heads_offset;
     let mut values = Vec::with_capacity(len);
-    let base_head_words = event_param_head_words(base)?;
     for _ in 0..len {
         values.push(decode_param_at(base, data, offset, offsets_base)?);
-        offset += base_head_words * 32;
+        offset = advance_offset(offset, base_head_words, &base.name)?;
     }
     Ok(Value::Array(values))
 }
@@ -410,14 +434,34 @@ fn is_tuple_param(input: &EventParam) -> bool {
 
 fn read_dynamic_bytes(data: &[u8], offset: usize, label: &str) -> SoldbResult<Vec<u8>> {
     let len = read_usize_word(data, offset, label)?;
-    let start = offset + 32;
-    let end = start + len;
-    if end > data.len() {
-        return Err(SoldbError::Message(format!(
+    // Both `offset` and `len` come from the payload; adding them unchecked wraps in release
+    // and produces a reversed range that panics on slicing.
+    let start = checked_offset(offset, 32, label)?;
+    let end = checked_offset(start, len, label)?;
+    data.get(start..end).map(<[u8]>::to_vec).ok_or_else(|| {
+        SoldbError::Message(format!(
             "Event dynamic bytes for {label} exceed data length"
-        )));
-    }
-    Ok(data[start..end].to_vec())
+        ))
+    })
+}
+
+/// Adds an untrusted ABI delta to an offset, reporting an error instead of overflowing.
+fn checked_offset(base: usize, delta: usize, label: &str) -> SoldbResult<usize> {
+    base.checked_add(delta).ok_or_else(|| {
+        SoldbError::Message(format!(
+            "Event offset for {label} overflows the address space"
+        ))
+    })
+}
+
+/// Advances a head cursor by `words` ABI words, reporting an error instead of overflowing.
+fn advance_offset(offset: usize, words: usize, label: &str) -> SoldbResult<usize> {
+    let advance = words.checked_mul(32).ok_or_else(|| {
+        SoldbError::Message(format!(
+            "Event head width for {label} overflows the address space"
+        ))
+    })?;
+    checked_offset(offset, advance, label)
 }
 
 fn read_usize_word(data: &[u8], offset: usize, label: &str) -> SoldbResult<usize> {
@@ -440,7 +484,7 @@ fn read_word_hex(data: &[u8], offset: usize) -> SoldbResult<String> {
 }
 
 fn read_word(data: &[u8], offset: usize) -> SoldbResult<&[u8]> {
-    let end = offset + 32;
+    let end = checked_offset(offset, 32, "ABI word")?;
     data.get(offset..end)
         .ok_or_else(|| SoldbError::Message("Event data is missing an ABI word".to_owned()))
 }
@@ -558,6 +602,65 @@ mod tests {
             ]
         }
     ]"#;
+
+    const BLOB_ABI: &str = r#"[
+        {
+            "type": "event",
+            "name": "Blob",
+            "inputs": [{"name": "payload", "type": "bytes", "indexed": false}]
+        }
+    ]"#;
+
+    const NUMBERS_ABI: &str = r#"[
+        {
+            "type": "event",
+            "name": "Numbers",
+            "inputs": [{"name": "values", "type": "uint256[]", "indexed": false}]
+        }
+    ]"#;
+
+    fn registry_for(abi: &str) -> (EventRegistry, String) {
+        let events = parse_event_abis(abi).expect("parse abi");
+        let topic = event_topic(&events[0]);
+        let mut registry = EventRegistry::default();
+        registry
+            .insert(None, events[0].clone())
+            .expect("insert event");
+        (registry, topic)
+    }
+
+    #[test]
+    fn rejects_dynamic_length_that_overflows_the_offset() {
+        let (registry, topic) = registry_for(BLOB_ABI);
+        // The head word points at offset 32, where the length word is `u64::MAX`. Adding
+        // that to the data start used to overflow: a panic in debug, and in release a
+        // wrapped end offset that produced a reversed slice range.
+        let data = format!("0x{:064x}{}{}", 32u64, "0".repeat(48), "f".repeat(16));
+
+        assert!(registry.decode_log(&[topic], &data).is_none());
+    }
+
+    #[test]
+    fn rejects_array_length_larger_than_the_event_data() {
+        let (registry, topic) = registry_for(NUMBERS_ABI);
+        // A one-element payload that claims to hold 2^40 elements. Reserving that many
+        // `Value`s up front is an immediate multi-terabyte allocation.
+        let data = format!("0x{:064x}{:064x}", 32u64, 1u64 << 40);
+
+        assert!(registry.decode_log(&[topic], &data).is_none());
+    }
+
+    #[test]
+    fn decodes_a_well_formed_dynamic_array() {
+        let (registry, topic) = registry_for(NUMBERS_ABI);
+        let data = format!("0x{:064x}{:064x}{:064x}{:064x}", 32u64, 2u64, 7u64, 8u64);
+
+        let decoded = registry
+            .decode_log(&[topic], &data)
+            .expect("decode dynamic array");
+
+        assert_eq!(decoded.args[0].value, json!([7, 8]));
+    }
 
     #[test]
     fn parses_event_abis_from_array() {

--- a/crates/soldb-ethdebug/src/events.rs
+++ b/crates/soldb-ethdebug/src/events.rs
@@ -1,3 +1,14 @@
+//! Decoding transaction logs against event ABIs.
+//!
+//! An [`EventRegistry`] is built from the event entries of one or more contract ABIs and
+//! keyed by topic hash, so a log can be matched and its indexed and non-indexed
+//! arguments decoded back into typed values.
+//!
+//! Log payloads come from the chain and are not trusted. Offsets and lengths read out of
+//! event data are validated and their arithmetic is checked: an unchecked offset wraps in
+//! release builds and turns into a reversed slice range, and an unchecked length turns
+//! into an unbounded allocation.
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};

--- a/crates/soldb-ethdebug/src/lib.rs
+++ b/crates/soldb-ethdebug/src/lib.rs
@@ -1,3 +1,22 @@
+//! Loading and interpreting compiler-generated Solidity debug information.
+//!
+//! This is the metadata half of an ETHDebug-first debugger: it turns `solc` artifacts
+//! into the program-counter, source-location, variable, and ABI lookups the rest of the
+//! workspace needs. Nothing here touches the network.
+//!
+//! - [`metadata`] models ETHDebug artifacts: instructions, their source spans, live
+//!   variable locations, and the `address:name:dir` contract specs used on the command
+//!   line.
+//! - [`source_map`] reads the legacy `srcmap` format, the fallback for compilers that
+//!   predate ETHDebug.
+//! - [`abi`] encodes calldata and parses function signatures, including tuples and
+//!   arrays, and carries the keccak-256 implementation used to derive selectors.
+//! - [`events`] decodes logs against event ABIs.
+//!
+//! Everything decoded here comes from files or from chain data, so it is untrusted:
+//! offsets and lengths read out of an artifact or a log payload are validated rather
+//! than trusted to be in range.
+
 pub mod abi;
 pub mod events;
 pub mod metadata;

--- a/crates/soldb-ethdebug/src/metadata.rs
+++ b/crates/soldb-ethdebug/src/metadata.rs
@@ -1,3 +1,14 @@
+//! ETHDebug artifact model: instructions, source spans, and variable locations.
+//!
+//! An ETHDebug runtime artifact is a list of instructions, each carrying its program
+//! counter and a `context` describing the source range it was generated from. Mapping a
+//! program counter back to Solidity means finding its instruction and reading that span.
+//!
+//! Spans nest: a compiler attaches a whole-contract range to dispatcher and preamble
+//! instructions, so a span containing a given line is not the same thing as a span
+//! generated for it. Callers that resolve a source line to a program counter must rank
+//! candidates accordingly rather than taking the first intersecting span.
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};

--- a/crates/soldb-ethdebug/src/source_map.rs
+++ b/crates/soldb-ethdebug/src/source_map.rs
@@ -1,3 +1,13 @@
+//! The legacy `srcmap` debug format.
+//!
+//! Compilers that predate ETHDebug emit source mappings as a compact `s:l:f:j:m` string
+//! alongside the bytecode, with fields inherited from the previous entry when omitted.
+//! This module parses that format and builds the program-counter index for it, which
+//! requires walking the bytecode so `PUSH` immediates are not mistaken for opcodes.
+//!
+//! This is a fallback path. ETHDebug is the primary source of debug information and
+//! carries strictly more of it; prefer it whenever the compiler can produce it.
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};

--- a/crates/soldb-repl/src/lib.rs
+++ b/crates/soldb-repl/src/lib.rs
@@ -56,6 +56,13 @@ pub enum DebuggerCommand {
     Step,
     Continue,
     Goto(usize),
+    /// List every source variable ETHDebug reports as live at the current program counter.
+    Vars,
+    /// Print one source variable by name at the current program counter.
+    ///
+    /// An empty name means the user typed `print` with no argument; the frontend reports
+    /// the usage rather than treating it as an unknown command.
+    Print(String),
     Info(DebuggerInfoCommand),
     Mode(Option<DisplayMode>),
     Break(BreakpointTarget),
@@ -86,6 +93,8 @@ impl DebuggerCommand {
             "nexti" | "ni" | "stepi" | "si" => Self::NextInstruction,
             "step" | "s" => Self::Step,
             "continue" | "c" => Self::Continue,
+            "vars" | "locals" => Self::Vars,
+            "print" | "p" => Self::Print(rest),
             "goto" => rest
                 .parse::<usize>()
                 .map(Self::Goto)
@@ -278,8 +287,10 @@ impl DebuggerState {
             | DebuggerCommand::Help(_)
             | DebuggerCommand::Info(_)
             | DebuggerCommand::Mode(None)
+            | DebuggerCommand::Print(_)
             | DebuggerCommand::Quit
-            | DebuggerCommand::Unknown(_) => None,
+            | DebuggerCommand::Unknown(_)
+            | DebuggerCommand::Vars => None,
         }
     }
 
@@ -369,6 +380,20 @@ mod tests {
         assert_eq!(DebuggerCommand::parse("s"), DebuggerCommand::Step);
         assert_eq!(DebuggerCommand::parse("c"), DebuggerCommand::Continue);
         assert_eq!(DebuggerCommand::parse("goto 2"), DebuggerCommand::Goto(2));
+        assert_eq!(DebuggerCommand::parse("vars"), DebuggerCommand::Vars);
+        assert_eq!(DebuggerCommand::parse("LOCALS"), DebuggerCommand::Vars);
+        assert_eq!(
+            DebuggerCommand::parse("print balance"),
+            DebuggerCommand::Print("balance".to_owned())
+        );
+        assert_eq!(
+            DebuggerCommand::parse("p   balance  "),
+            DebuggerCommand::Print("balance".to_owned())
+        );
+        assert_eq!(
+            DebuggerCommand::parse("print"),
+            DebuggerCommand::Print(String::new())
+        );
         assert_eq!(
             DebuggerCommand::parse("info resources"),
             DebuggerCommand::Info(DebuggerInfoCommand::Resources { json: false })

--- a/crates/soldb-repl/src/lib.rs
+++ b/crates/soldb-repl/src/lib.rs
@@ -1,3 +1,15 @@
+//! The interactive debugger's command parser and state machine.
+//!
+//! [`DebuggerCommand::parse`] turns a typed line into a command, and
+//! [`DebuggerState::apply_command`] applies the ones that move the debugger, returning a
+//! [`StepOutcome`] describing what happened.
+//!
+//! This crate performs no I/O: it neither reads stdin nor prints. The frontend owns the
+//! terminal and renders outcomes, which is what makes stepping, breakpoints, and command
+//! parsing testable without a terminal or a node. Commands that need context the state
+//! machine does not have — source-line breakpoints, variable lookups — return `None`
+//! from `apply_command` and are resolved by the frontend against ETHDebug metadata.
+
 use std::collections::BTreeSet;
 
 use soldb_core::{TraceStep, TransactionTrace};

--- a/crates/soldb-rpc/src/lib.rs
+++ b/crates/soldb-rpc/src/lib.rs
@@ -2316,16 +2316,16 @@ fn hex_to_bytes(hex: &str) -> Option<Vec<u8>> {
     // Hex strings reach us from RPC responses and CLI arguments, so they are not
     // guaranteed to be ASCII. Slicing by byte offset would panic on a multi-byte
     // character whose boundary falls inside a pair; decode over bytes instead.
-    let digits = hex.as_bytes();
-    if !digits.len().is_multiple_of(2) {
+    let (pairs, remainder) = hex.as_bytes().as_chunks::<2>();
+    if !remainder.is_empty() {
         return None;
     }
 
-    digits
-        .chunks_exact(2)
-        .map(|pair| {
-            let high = char::from(pair[0]).to_digit(16)?;
-            let low = char::from(pair[1]).to_digit(16)?;
+    pairs
+        .iter()
+        .map(|[high, low]| {
+            let high = char::from(*high).to_digit(16)?;
+            let low = char::from(*low).to_digit(16)?;
             u8::try_from(high * 16 + low).ok()
         })
         .collect()

--- a/crates/soldb-rpc/src/lib.rs
+++ b/crates/soldb-rpc/src/lib.rs
@@ -444,10 +444,66 @@ pub struct StructLog {
     pub error: Option<String>,
 }
 
+/// Joins a `structLogs` memory array into one unprefixed hex string.
+///
+/// Nodes disagree on whether the words carry a `0x` prefix. Joining prefixed words
+/// verbatim produces `0x..0x..0x..`, which is neither valid hex nor indexable by byte
+/// offset, and it makes this backend disagree with the replay backend, which emits one
+/// unprefixed string. A step's memory is documented to be a flat byte sequence, and
+/// byte-offset lookups such as memory-located variable decoding assume exactly that.
+fn joined_memory(words: &[String]) -> String {
+    words
+        .iter()
+        .map(|word| {
+            word.strip_prefix("0x")
+                .or_else(|| word.strip_prefix("0X"))
+                .unwrap_or(word)
+        })
+        .collect()
+}
+
 impl StructLog {
     #[must_use]
     pub fn into_trace_step(self) -> TraceStep {
         self.into_trace_step_with_previous_storage(&BTreeMap::new())
+    }
+
+    /// Builds a [`TraceStep`] from a borrowed log.
+    ///
+    /// Prefer this when walking a whole trace: the owning version cannot be used without
+    /// first cloning the log, which doubles the per-step copying for no benefit.
+    ///
+    /// A `TraceStep` records its stack, memory, and storage twice — once in the flat
+    /// fields and once in the snapshot — so two copies of each are unavoidable here. That
+    /// is the floor, and this function stays at it.
+    #[must_use]
+    pub fn to_trace_step_with_previous_storage(
+        &self,
+        previous_storage: &BTreeMap<String, String>,
+    ) -> TraceStep {
+        let memory = joined_memory(&self.memory);
+        let snapshot = StepSnapshot {
+            stack: self.stack.clone(),
+            memory: Some(memory.clone()),
+            storage: self.storage.clone(),
+            storage_diff: if self.storage.is_empty() {
+                BTreeMap::new()
+            } else {
+                storage_diff(previous_storage, &self.storage)
+            },
+        };
+        TraceStep {
+            pc: self.pc,
+            op: self.op.clone(),
+            gas: self.gas,
+            gas_cost: self.gas_cost,
+            depth: self.depth,
+            stack: self.stack.clone(),
+            memory: Some(memory),
+            storage: Some(self.storage.clone()),
+            error: self.error.clone(),
+            snapshot,
+        }
     }
 
     #[must_use]
@@ -455,16 +511,16 @@ impl StructLog {
         self,
         previous_storage: &BTreeMap<String, String>,
     ) -> TraceStep {
-        let memory = Some(self.memory.join(""));
-        let storage = self.storage.clone();
+        let memory = joined_memory(&self.memory);
+        // Clone into the snapshot first, then move the originals into the flat fields.
         let snapshot = StepSnapshot {
             stack: self.stack.clone(),
-            memory: memory.clone(),
-            storage: storage.clone(),
-            storage_diff: if storage.is_empty() {
+            memory: Some(memory.clone()),
+            storage: self.storage.clone(),
+            storage_diff: if self.storage.is_empty() {
                 BTreeMap::new()
             } else {
-                storage_diff(previous_storage, &storage)
+                storage_diff(previous_storage, &self.storage)
             },
         };
         TraceStep {
@@ -474,7 +530,7 @@ impl StructLog {
             gas_cost: self.gas_cost,
             depth: self.depth,
             stack: self.stack,
-            memory,
+            memory: Some(memory),
             storage: Some(self.storage),
             error: self.error,
             snapshot,
@@ -2318,7 +2374,7 @@ mod tests {
                     "gasCost": 3,
                     "depth": 0,
                     "stack": ["0x01"],
-                    "memory": ["aa", "bb"],
+                    "memory": ["0xaa", "bb"],
                     "storage": {"0x00": "0x2a"}
                 },
                 {"pc": 2, "op": "STOP", "gas": 97, "depth": 0}
@@ -2328,6 +2384,8 @@ mod tests {
 
         let steps = result.steps();
         assert_eq!(steps.len(), 2);
+        // Memory words are normalized to one unprefixed hex string whether or not the node
+        // prefixed them, so byte-offset lookups stay valid and both backends agree.
         assert_eq!(steps[0].memory.as_deref(), Some("aabb"));
         assert_eq!(steps[0].storage.as_ref().expect("storage")["0x00"], "0x2a");
         assert_eq!(steps[0].snapshot.stack, ["0x01"]);

--- a/crates/soldb-rpc/src/lib.rs
+++ b/crates/soldb-rpc/src/lib.rs
@@ -643,15 +643,16 @@ enum RpcBlockTransaction {
 impl DebugTraceResult {
     #[must_use]
     pub fn steps(&self) -> Vec<TraceStep> {
-        let mut previous_storage = BTreeMap::<String, String>::new();
+        static EMPTY_STORAGE: BTreeMap<String, String> = BTreeMap::new();
+
+        // Borrow the previous log's storage rather than copying it forward: this runs once
+        // per EVM step, and a trace can have hundreds of thousands of them.
+        let mut previous_storage = &EMPTY_STORAGE;
         self.struct_logs
             .iter()
-            .cloned()
             .map(|log| {
-                let step = log
-                    .clone()
-                    .into_trace_step_with_previous_storage(&previous_storage);
-                previous_storage = log.storage;
+                let step = log.to_trace_step_with_previous_storage(previous_storage);
+                previous_storage = &log.storage;
                 step
             })
             .collect()
@@ -851,10 +852,21 @@ fn debug_rpc_capabilities(result: &DebugTraceResult) -> TraceCapabilities {
         .struct_logs
         .iter()
         .any(|step| !step.storage.is_empty());
-    let has_storage_diff = result
-        .steps()
-        .iter()
-        .any(|step| !step.snapshot.storage_diff.is_empty());
+    // Whether any step reports a storage change, read straight off the logs. Calling
+    // `steps()` here would build the entire trace a second time — hundreds of thousands of
+    // steps, each with a copy of the stack and of all of memory — and then throw it away to
+    // answer a boolean. This mirrors what `to_trace_step_with_previous_storage` computes:
+    // a step has a diff when its own storage is non-empty and differs from the previous
+    // step's.
+    let has_storage_diff = {
+        static EMPTY_STORAGE: BTreeMap<String, String> = BTreeMap::new();
+        let mut previous = &EMPTY_STORAGE;
+        result.struct_logs.iter().any(|log| {
+            let changed = !log.storage.is_empty() && *previous != log.storage;
+            previous = &log.storage;
+            changed
+        })
+    };
     let mut notes = Vec::new();
     if has_steps && !has_storage {
         notes.push("debug-rpc node did not return per-step storage".to_owned());
@@ -1688,6 +1700,13 @@ struct ReplayStepInspector {
     call_stack: Vec<usize>,
     create_stack: Vec<usize>,
     journal_entries_seen: usize,
+    /// EVM memory as of the last step that changed it, with its hex encoding.
+    ///
+    /// Most instructions leave memory untouched, but the inspector records memory on every
+    /// step. Without this the encoder runs a full pass over memory per step even when
+    /// nothing moved.
+    last_memory: Vec<u8>,
+    last_memory_hex: String,
 }
 
 impl ReplayStepInspector {
@@ -1718,7 +1737,20 @@ where
             .iter()
             .map(|value| format_u256_quantity(*value))
             .collect();
-        let memory = bytes_to_hex(interp.memory.slice(0..interp.memory.size()).as_ref());
+        {
+            let memory_slice = interp.memory.slice(0..interp.memory.size());
+            let memory_bytes: &[u8] = memory_slice.as_ref();
+            if self.last_memory != memory_bytes {
+                self.last_memory.clear();
+                self.last_memory.extend_from_slice(memory_bytes);
+                self.last_memory_hex = bytes_to_hex(memory_bytes);
+            }
+        }
+        let memory = if self.last_memory_hex.is_empty() {
+            Vec::new()
+        } else {
+            vec![self.last_memory_hex.clone()]
+        };
         self.pending = Some(StructLog {
             pc: interp.bytecode.pc() as u64,
             op,
@@ -1726,10 +1758,7 @@ where
             gas_cost: 0,
             depth: context.journal_mut().depth() as u64,
             stack,
-            memory: memory
-                .is_empty()
-                .then(Vec::new)
-                .unwrap_or_else(|| vec![memory]),
+            memory,
             storage: BTreeMap::new(),
             error: None,
         });
@@ -2361,6 +2390,69 @@ mod tests {
     };
     use serde_json::{json, Value};
     use soldb_core::TransactionTrace;
+
+    #[test]
+    fn storage_diff_capability_matches_the_materialized_steps() {
+        // `debug_rpc_capabilities` reads the storage-diff flag off the raw logs instead of
+        // building every step. Pin it against the definition it replaces.
+        let log = |storage: &[(&str, &str)]| StructLog {
+            pc: 0,
+            op: "SSTORE".to_owned(),
+            gas: 0,
+            gas_cost: 0,
+            depth: 0,
+            stack: Vec::new(),
+            memory: Vec::new(),
+            storage: storage
+                .iter()
+                .map(|(slot, value)| ((*slot).to_owned(), (*value).to_owned()))
+                .collect(),
+            error: None,
+        };
+
+        let cases = [
+            Vec::new(),
+            vec![log(&[])],
+            vec![log(&[("0x00", "0x01")])],
+            vec![log(&[("0x00", "0x01")]), log(&[("0x00", "0x01")])],
+            vec![log(&[("0x00", "0x01")]), log(&[("0x00", "0x02")])],
+            vec![log(&[("0x00", "0x01")]), log(&[])],
+            vec![log(&[]), log(&[("0x00", "0x01")])],
+        ];
+
+        for struct_logs in cases {
+            let result = DebugTraceResult {
+                struct_logs,
+                return_value: String::new(),
+                error: None,
+                failed: false,
+                gas: None,
+                artifacts: TraceArtifacts::default(),
+            };
+            let materialized = result
+                .steps()
+                .iter()
+                .any(|step| !step.snapshot.storage_diff.is_empty());
+            assert_eq!(
+                super::debug_rpc_capabilities(&result).storage_diff,
+                materialized,
+                "logs: {:?}",
+                result.struct_logs
+            );
+        }
+    }
+
+    #[test]
+    fn hex_decoding_rejects_non_ascii_without_panicking() {
+        // Hex strings arrive from RPC responses and CLI arguments. Slicing them by byte
+        // offset panicked when a multi-byte character straddled a digit pair.
+        assert_eq!(super::hex_to_bytes("\u{20ac}\u{20ac}"), None);
+        assert_eq!(super::hex_to_bytes("0\u{20ac}"), None);
+        assert_eq!(super::hex_to_bytes("zz"), None);
+        assert_eq!(super::hex_to_bytes("abc"), None);
+        assert_eq!(super::hex_to_bytes("0a1B"), Some(vec![0x0a, 0x1b]));
+        assert_eq!(super::hex_to_bytes(""), Some(Vec::new()));
+    }
 
     #[test]
     fn parses_struct_logs_into_trace_steps() {

--- a/crates/soldb-rpc/src/lib.rs
+++ b/crates/soldb-rpc/src/lib.rs
@@ -2228,24 +2228,36 @@ fn parse_b256(value: &str) -> SoldbResult<B256> {
 }
 
 fn hex_to_bytes(hex: &str) -> Option<Vec<u8>> {
-    if !hex.len().is_multiple_of(2) {
+    // Hex strings reach us from RPC responses and CLI arguments, so they are not
+    // guaranteed to be ASCII. Slicing by byte offset would panic on a multi-byte
+    // character whose boundary falls inside a pair; decode over bytes instead.
+    let digits = hex.as_bytes();
+    if !digits.len().is_multiple_of(2) {
         return None;
     }
 
-    (0..hex.len())
-        .step_by(2)
-        .map(|index| u8::from_str_radix(&hex[index..index + 2], 16).ok())
+    digits
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = char::from(pair[0]).to_digit(16)?;
+            let low = char::from(pair[1]).to_digit(16)?;
+            u8::try_from(high * 16 + low).ok()
+        })
         .collect()
 }
 
 fn bytes_to_hex(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut encoded = String::with_capacity(bytes.len() * 2);
+    // Fill an ASCII byte buffer and validate it once. `String::push` re-runs UTF-8
+    // encoding for every character, which is measurable when the replay inspector encodes
+    // the whole of EVM memory.
+    let mut encoded = Vec::with_capacity(bytes.len() * 2);
     for byte in bytes {
-        encoded.push(HEX[(byte >> 4) as usize] as char);
-        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+        encoded.push(HEX[usize::from(byte >> 4)]);
+        encoded.push(HEX[usize::from(byte & 0x0f)]);
     }
-    encoded
+    // `HEX` holds only ASCII, so the buffer is valid UTF-8 by construction.
+    String::from_utf8(encoded).expect("hex digits are ASCII")
 }
 
 fn bytes_to_prefixed_hex(bytes: &[u8]) -> String {

--- a/crates/soldb-rpc/src/lib.rs
+++ b/crates/soldb-rpc/src/lib.rs
@@ -1,3 +1,20 @@
+//! Ethereum JSON-RPC transport and the execution backends built on it.
+//!
+//! This is the only crate that talks to a node. It provides the HTTP/HTTPS JSON-RPC
+//! client, transaction and receipt lookups, log retrieval, `debug_traceCall`
+//! simulation, and the two ways of producing an execution trace:
+//!
+//! - the `debug-rpc` backend, which asks the node to replay the transaction through
+//!   `debug_traceTransaction`, and
+//! - the `replay` backend, which reads the state a transaction touched over ordinary
+//!   RPC, re-executes any earlier transactions in the block, and then runs the target
+//!   through REVM with inspectors attached.
+//!
+//! Both backends produce the same [`soldb_core::TransactionTrace`], and each reports
+//! what it was able to capture through `TraceCapabilities` so callers never have to
+//! branch on the backend name. Backend-specific quirks belong here rather than in the
+//! frontends.
+
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;

--- a/crates/soldb-serializer/src/lib.rs
+++ b/crates/soldb-serializer/src/lib.rs
@@ -104,8 +104,8 @@ fn web_steps(trace: &TransactionTrace) -> Vec<serde_json::Value> {
                 "gas": step.gas,
                 "gasCost": step.gas_cost,
                 "depth": step.depth,
-                "stack": step.stack,
-                "snapshot": step.normalized_snapshot(),
+                "stack": step.snapshot_ref().stack,
+                "snapshot": step.snapshot_ref(),
             })
         })
         .collect()

--- a/crates/soldb-serializer/src/lib.rs
+++ b/crates/soldb-serializer/src/lib.rs
@@ -9,7 +9,7 @@
 //! artifacts can be deserialized from a trace file, the reconstruction tolerates parent
 //! links that do not form a tree instead of recursing on a cycle.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 use serde_json::json;
@@ -208,23 +208,29 @@ fn trace_call_from_artifacts(trace: &TransactionTrace) -> Option<TraceCallWeb> {
         .into_iter()
         .map(|node| (node.call_id, node))
         .collect::<BTreeMap<_, _>>();
-    Some(build_trace_call_node(root_id, &by_id))
+    build_trace_call_node(root_id, &by_id, &mut BTreeSet::new())
 }
 
-fn build_trace_call_node(call_id: u64, by_id: &BTreeMap<u64, ArtifactCallNode>) -> TraceCallWeb {
-    let node = by_id
-        .get(&call_id)
-        .expect("trace call tree references a missing node");
-    let child_ids = by_id
+fn build_trace_call_node(
+    call_id: u64,
+    by_id: &BTreeMap<u64, ArtifactCallNode>,
+    visited: &mut BTreeSet<u64>,
+) -> Option<TraceCallWeb> {
+    // Call artifacts are deserialized from backend output and from trace files handed to
+    // the DAP server, so the parent links are not guaranteed to form a tree. Refuse to
+    // revisit a call: a cycle would otherwise recurse until the stack overflows, which is
+    // not something a caller can catch.
+    if !visited.insert(call_id) {
+        return None;
+    }
+    let node = by_id.get(&call_id)?;
+    let calls = by_id
         .values()
         .filter(|candidate| candidate.parent_call_id == Some(call_id))
-        .map(|candidate| candidate.call_id)
+        .filter_map(|candidate| build_trace_call_node(candidate.call_id, by_id, visited))
         .collect::<Vec<_>>();
-    let calls = child_ids
-        .iter()
-        .map(|child_id| build_trace_call_node(*child_id, by_id))
-        .collect();
-    TraceCallWeb {
+    let child_ids = calls.iter().map(|child| child.call_id).collect::<Vec<_>>();
+    Some(TraceCallWeb {
         ty: node.ty.clone(),
         call_id: node.call_id,
         parent_call_id: node.parent_call_id,
@@ -239,7 +245,7 @@ fn build_trace_call_node(call_id: u64, by_id: &BTreeMap<u64, ArtifactCallNode>) 
         output: node.output.clone(),
         is_reverted_frame: node.is_reverted_frame,
         calls,
-    }
+    })
 }
 
 fn artifact_call_nodes(trace: &TransactionTrace) -> Vec<ArtifactCallNode> {
@@ -423,6 +429,50 @@ mod tests {
         assert_eq!(value["schemaVersion"], 1);
         assert_eq!(value["traceCall"]["functionName"], "raw_data");
         assert_eq!(value["steps"][0]["traceCallIndex"], 0);
+    }
+
+    fn call_node(id: usize, parent_id: Option<usize>) -> ExecutionCall {
+        ExecutionCall {
+            id,
+            parent_id,
+            depth: 0,
+            entry_step: None,
+            exit_step: None,
+            call_type: "call".to_owned(),
+            from: "0x1".to_owned(),
+            to: "0x2".to_owned(),
+            bytecode_address: "0x2".to_owned(),
+            value: "0x0".to_owned(),
+            input: "0x".to_owned(),
+            gas_limit: 0,
+            gas_used: None,
+            output: None,
+            success: Some(true),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn cyclic_artifact_calls_do_not_recurse_forever() {
+        // A trace file whose call parents form a cycle used to recurse until the stack
+        // overflowed, which aborts the process instead of surfacing an error.
+        let mut trace = sample_trace();
+        trace.artifacts = TraceArtifacts {
+            calls: vec![call_node(0, Some(1)), call_node(1, Some(0))],
+            ..Default::default()
+        };
+
+        let json = trace_to_web_json(&trace).expect("serialize cyclic trace");
+        let value = serde_json::from_str::<serde_json::Value>(&json).expect("valid json");
+
+        assert_eq!(value["traceCall"]["callId"], 0);
+        assert_eq!(value["traceCall"]["calls"][0]["callId"], 1);
+        assert_eq!(
+            value["traceCall"]["calls"][0]["calls"]
+                .as_array()
+                .map(Vec::len),
+            Some(0)
+        );
     }
 
     #[test]

--- a/crates/soldb-serializer/src/lib.rs
+++ b/crates/soldb-serializer/src/lib.rs
@@ -1,3 +1,14 @@
+//! The web-facing JSON projection of traces and simulations.
+//!
+//! `soldb trace --json` and `soldb simulate --json` are consumed by explorers and web
+//! clients, so the document produced here is a versioned contract rather than a debug
+//! dump. `docs/json.md` is its specification and is updated alongside this module.
+//!
+//! [`WEB_JSON_SCHEMA_VERSION`] increments only for breaking changes; adding a field is
+//! additive. Call artifacts are rebuilt into a nested call tree, and because those
+//! artifacts can be deserialized from a trace file, the reconstruction tolerates parent
+//! links that do not form a tree instead of recursing on a cycle.
+
 use std::collections::BTreeMap;
 
 use serde::Serialize;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,20 +55,30 @@ PC 123 → TestContract.sol:39:15 (line 39, column 15)
 - `Contract_ethdebug.json` - Constructor debug info
 - `Contract_ethdebug-runtime.json` - Runtime debug info with instruction mappings
 
-Each instruction entry contains:
+Each instruction entry contains its program counter (`offset`), its operation, and a
+`context` naming the source range it was generated from:
+
 ```json
 {
-  "opcode": "PUSH1",
-  "value": "0x4",
+  "offset": 5,
+  "operation": {
+    "mnemonic": "PUSH1",
+    "arguments": ["0x04"]
+  },
   "context": {
-    "source": {
-      "id": 0,
-      "offset": 523,
-      "length": 1
+    "code": {
+      "source": {"id": 0},
+      "range": {"offset": 144, "length": 2771}
     }
   }
 }
 ```
+
+Source ranges nest. The compiler attaches a whole-contract range to dispatcher and
+preamble instructions, so a range that contains a given line is not necessarily a range
+generated for it. Resolving a source line to a program counter therefore prefers
+instructions whose range *begins* on that line, falling back to the narrowest range that
+merely intersects it.
 
 ### 4. Function Call Analysis
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -116,6 +116,48 @@ soldb> mode asm
 soldb> mode assembly
 ```
 
+## Variables
+
+Both commands read the ETHDebug variable information for the current program counter, so
+the session must be started with `--ethdebug-dir <address>:<contract>:<dir>`. They share
+their decoding with the DAP server's variables view.
+
+Note that a compiler only reports variables if it emits `context.variables` in its
+ETHDebug output. Compilers that do not yet emit it make these commands report that
+nothing is in scope, which is a limitation of the debug info rather than of the lookup.
+
+### `vars`
+
+Aliases: `locals`
+
+Print every source variable ETHDebug reports as live at the current program counter, with
+its declared type, decoded value, and the location the value was read from.
+
+```text
+soldb> vars
+uint256 amount = 5 [stack+2]
+uint256 oldValue = 0 [stack+1]
+```
+
+A value shown as `<unavailable>` means the backend did not capture the stack, memory, or
+storage the variable lives in — not that the variable is unset.
+
+### `print <variable>`
+
+Aliases: `p <variable>`
+
+Print one variable by name.
+
+```text
+soldb> print amount
+uint256 amount = 5 [stack+2]
+soldb> p oldValue
+uint256 oldValue = 0 [stack+1]
+```
+
+If the name is not live at the current program counter, SolDB says so and names the PC it
+looked at, so you can step to a point where the variable is in scope.
+
 ## Metadata
 
 ### `info resources`
@@ -154,8 +196,12 @@ soldb> b 0x8d
 
 Aliases: `b <file>:<line>`
 
-Set a breakpoint at the first EVM program counter mapped to a source line by
-ETHDebug metadata.
+Set a breakpoint at the first executed EVM program counter generated for a source line.
+
+Among the instructions whose ETHDebug span touches the line, SolDB prefers those whose
+span *begins* on it. Compilers attach a whole-contract span to the dispatcher preamble,
+and that span technically contains every line, so without this preference every source
+breakpoint would resolve to the start of the contract.
 
 ```text
 soldb> break Counter.sol:7
@@ -218,8 +264,24 @@ Current output:
 Commands: next, nexti, step, continue, goto <step>
           break <pc>|<file>:<line>|line <line>
           clear <pc>|<file>:<line>|line <line>
+          vars, print <variable>
           info resources [--json]
           mode source|asm, help, quit
+```
+
+### `help vars`
+
+Print help for variable inspection. `help locals` and `help print` show the same text.
+
+```text
+soldb> help vars
+```
+
+Current output:
+
+```text
+vars - print every source variable live at the current PC
+print <variable> - print one source variable by name
 ```
 
 ### `help info`

--- a/test/cli/ethdebug-load-failure.test
+++ b/test/cli/ethdebug-load-failure.test
@@ -1,0 +1,28 @@
+# Test that ETHDebug load failures are reported instead of silently degrading
+# REQUIRES: soldb
+#
+# Note: avoid the bare word `not` surrounded by non-word characters anywhere in this file.
+# lit substitutes it with LLVM's `not` binary, and `missing-ethdebug` below is deliberately
+# spelled without it.
+
+# A directory that holds no ETHDebug artifacts is reported, not silently ignored. The user
+# asked for ETHDebug by naming the directory, so "no source lines" must not look identical
+# to a contract compiled without debug info.
+# RUN: %soldb trace %{test_tx} --ethdebug-dir %{contract_address}:TestContract:%{project_root}/test/missing-ethdebug 2>&1 >/dev/null --rpc %{rpc_url} | FileCheck %s --check-prefix=MISSING
+
+# MISSING: warning: could not load ETHDebug metadata for `TestContract`
+# MISSING: note: source lines, variables, and decoded parameters are unavailable
+
+# A spec that resolves to no contract at all is reported too.
+# RUN: %soldb trace %{test_tx} --ethdebug-dir %{project_root}/test/missing-ethdebug 2>&1 >/dev/null --rpc %{rpc_url} | FileCheck %s --check-prefix=UNRESOLVED
+
+# UNRESOLVED: warning: could not resolve the requested contracts
+# UNRESOLVED-SAME: no contracts found for
+
+# The report goes to stderr, so `--json` still emits one valid document on stdout.
+# RUN: %soldb trace %{test_tx} --ethdebug-dir %{contract_address}:TestContract:%{project_root}/test/missing-ethdebug --rpc %{rpc_url} --json 2>/dev/null | jq -e '.schemaVersion == 1 and (.steps | length) > 0' > /dev/null
+
+# A healthy ETHDebug directory reports nothing at all.
+# RUN: %soldb trace %{test_tx} --ethdebug-dir %{contract_address}:TestContract:%{ethdebug_dir} 2>&1 >/dev/null --rpc %{rpc_url} | FileCheck %s --check-prefix=QUIET --allow-empty
+
+# QUIET-NOT: warning:

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -123,7 +123,10 @@ if not not_path:
             not_path = candidate
             break
 if not_path:
-    config.substitutions.append(('not', not_path))
+    # Anchor on word boundaries. lit substitutions are regular expressions applied to the
+    # whole RUN line, so a bare 'not' also rewrites the substring inside identifiers,
+    # paths, and expected output such as 'definitely_not_a_variable'.
+    config.substitutions.append((r'\bnot\b', not_path))
 
 # Find and add FileCheck
 filecheck_path = None

--- a/test/trace/interactive-variables.test
+++ b/test/trace/interactive-variables.test
@@ -1,0 +1,24 @@
+# Test the interactive debugger's variable inspection commands
+# REQUIRES: soldb
+
+# `vars` and `print` need ETHDebug metadata; without it the debugger says so instead of
+# silently printing nothing.
+# RUN: printf 'vars\nprint counter\nquit\n' | %soldb trace %{test_tx} --rpc %{rpc_url} -i 2>&1 | FileCheck %s --check-prefix=NOMETA
+
+# NOMETA: Cannot read variables: no ETHDebug metadata is loaded
+# NOMETA: --ethdebug-dir
+# NOMETA: Cannot read variables: no ETHDebug metadata is loaded
+
+# With metadata loaded, an unknown name is reported against the current program counter
+# rather than being treated as an unknown command.
+# RUN: printf 'print definitely_not_a_variable\nprint\nquit\n' | %soldb trace %{test_tx} --ethdebug-dir %{contract_address}:TestContract:%{ethdebug_dir} --rpc %{rpc_url} -i 2>&1 | FileCheck %s --check-prefix=LOOKUP
+
+# LOOKUP: No such variable: `definitely_not_a_variable` is not in scope at PC {{[0-9]+}}
+# LOOKUP: Usage: print <variable>
+
+# Both commands are advertised in the REPL help.
+# RUN: printf 'help\nhelp vars\nquit\n' | %soldb trace %{test_tx} --rpc %{rpc_url} -i 2>&1 | FileCheck %s --check-prefix=HELP
+
+# HELP: vars, print <variable>
+# HELP: vars - print every source variable live at the current PC
+# HELP: print <variable> - print one source variable by name


### PR DESCRIPTION
Add AGENTS.md with guidance for coding agents, and apply the new rules.

| Metric | `debug-rpc` | `replay` |
|---|---|---|
| Trace construction | 11.67s → **9.74s** (17% faster) | 2.18s → **1.45s** (33% faster) |
| End-to-end `--json` | 15.55s → **13.31s** (14% faster) | 5.09s → **4.80s** (6% faster) |
| Peak RSS (construction) | 8385 → **7735 MiB** (650 MiB less) | unchanged |
