### PR TITLE
Dual-license under GPL-3.0-only OR MIT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-license = "GPL-3.0-only"
+license = "GPL-3.0-only OR MIT"
 repository = "https://github.com/walnuthq/soldb"
 
 [workspace.dependencies]

--- a/LICENSE-MIT.md
+++ b/LICENSE-MIT.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Walnut and the SolDB contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SolDB – ETHDebug-First Solidity Debugger
 
 [![CI](https://github.com/walnuthq/soldb/actions/workflows/ci.yml/badge.svg)](https://github.com/walnuthq/soldb/actions/workflows/ci.yml)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![License: GPL v3 or MIT](https://img.shields.io/badge/License-GPLv3%20or%20MIT-blue.svg)](#license)
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org/)
 
 > **Note**: SolDB is in public beta; expect ongoing changes and occasional inaccuracies.  
@@ -329,9 +329,12 @@ make coverage
 
 ## License
 
-SolDB is licensed under the GNU General Public License v3.0 (GPL-3.0), the same license used by Solidity and other Ethereum Foundation projects.
+SolDB is dual-licensed under the GNU General Public License v3.0 or the MIT
+license, at your option: use, redistribute, and modify it under the terms of
+either one. Unless you state otherwise, contributions you submit are
+dual-licensed the same way.
 
-📄 [Full license](./LICENSE.md)
+📄 [GPL-3.0](./LICENSE.md) · [MIT](./LICENSE-MIT.md)
 
 ## Community & Support
 💬 Join our Telegram: [@walnut_soldb](https://t.me/walnut_soldb)


### PR DESCRIPTION
Add the MIT license as an option alongside GPL-3.0 so permissively licensed projects (e.g. Foundry, MIT/Apache-2.0) can link the SolDB crates directly. Every crate inherits the workspace license field. Approval of this PR by each past contributor records their consent to offering their contributions under the MIT license as well.


