### PR TITLE
feat: prepare crates.io publish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,16 +86,19 @@ Crate dependencies, as actually declared in `crates/*/Cargo.toml`:
 | crate | depends on |
 | --- | --- |
 | `soldb-core` | *(nothing)* |
-| `soldb-ethdebug` | core |
+| `soldb-ethdebug` | core, `revm-bytecode` |
 | `soldb-rpc` | core, `revm` |
 | `soldb-repl` | core |
 | `soldb-serializer` | core |
 | `soldb-debugger` | core, ethdebug |
-| `soldb-profiler` | core, debugger, ethdebug |
+| `soldb-profiler` | core, ethdebug |
 | `soldb-bridge` | core, rpc |
 | `soldb-compiler` | core, ethdebug, rpc |
 | `soldb-dap` | core, ethdebug, rpc, repl, debugger |
-| `soldb-cli` | core, ethdebug, rpc, repl, debugger, profiler, serializer, compiler, bridge |
+| `soldb-cli` | core, ethdebug, rpc, repl, debugger, profiler, serializer, compiler, bridge, `inferno` |
+
+The crate in `crates/soldb-cli` is named `soldb` on crates.io, so the install is
+`cargo install soldb`; the directory keeps the `soldb-cli` name to match its siblings.
 
 `soldb-debugger` is the shared frontend model, and both `soldb-cli` and `soldb-dap` go
 through it for variable decoding so the terminal and an editor report the same values.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,17 +2591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "soldb-bridge"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
- "soldb-core",
- "soldb-rpc",
-]
-
-[[package]]
-name = "soldb-cli"
+name = "soldb"
 version = "0.1.0"
 dependencies = [
  "clap",
@@ -2617,6 +2607,16 @@ dependencies = [
  "soldb-repl",
  "soldb-rpc",
  "soldb-serializer",
+]
+
+[[package]]
+name = "soldb-bridge"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "soldb-core",
+ "soldb-rpc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,26 @@ version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only OR MIT"
 repository = "https://github.com/walnuthq/soldb"
+homepage = "https://github.com/walnuthq/soldb"
+keywords = ["solidity", "evm", "ethereum", "debugger", "ethdebug"]
+categories = ["development-tools::debugging"]
+readme = "README.md"
 
 [workspace.dependencies]
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+soldb-bridge = { path = "crates/soldb-bridge", version = "0.1.0" }
+soldb-compiler = { path = "crates/soldb-compiler", version = "0.1.0" }
+soldb-core = { path = "crates/soldb-core", version = "0.1.0" }
+soldb-dap = { path = "crates/soldb-dap", version = "0.1.0" }
+soldb-debugger = { path = "crates/soldb-debugger", version = "0.1.0" }
+soldb-ethdebug = { path = "crates/soldb-ethdebug", version = "0.1.0" }
+soldb-profiler = { path = "crates/soldb-profiler", version = "0.1.0" }
+soldb-repl = { path = "crates/soldb-repl", version = "0.1.0" }
+soldb-rpc = { path = "crates/soldb-rpc", version = "0.1.0" }
+soldb-serializer = { path = "crates/soldb-serializer", version = "0.1.0" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -19,12 +19,17 @@ SolDB is an open-source, ETHDebug-first, LLDB-style debugger for Solidity and th
 
 Install SolDB:
 ```bash
-cargo install --git https://github.com/walnuthq/soldb.git soldb-cli
+cargo install soldb
 ```
 
 Optional debug-adapter binary:
 ```bash
-cargo install --git https://github.com/walnuthq/soldb.git soldb-dap
+cargo install soldb-dap
+```
+
+To track the development branch instead, install from git:
+```bash
+cargo install --git https://github.com/walnuthq/soldb.git soldb
 ```
 
 Run against a local node (Anvil):

--- a/crates/soldb-bridge/Cargo.toml
+++ b/crates/soldb-bridge/Cargo.toml
@@ -2,8 +2,13 @@
 name = "soldb-bridge"
 version.workspace = true
 edition.workspace = true
+description = "Cross-VM bridge protocol and server for SolDB, supporting Stylus interop"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 doctest = false
@@ -11,8 +16,8 @@ doctest = false
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-soldb-core = { path = "../soldb-core" }
-soldb-rpc = { path = "../soldb-rpc" }
+soldb-core.workspace = true
+soldb-rpc.workspace = true
 
 [lints]
 workspace = true

--- a/crates/soldb-cli/Cargo.toml
+++ b/crates/soldb-cli/Cargo.toml
@@ -1,9 +1,17 @@
 [package]
-name = "soldb-cli"
+name = "soldb"
 version.workspace = true
 edition.workspace = true
+description = "An ETHDebug-first, LLDB-style debugger for Solidity and the EVM"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories = ["development-tools::debugging", "command-line-utilities"]
+# The integration tests read fixtures from `test/` at the repository root, which
+# is outside the published package.
+exclude = ["tests"]
 
 [[bin]]
 name = "soldb"
@@ -14,15 +22,15 @@ clap.workspace = true
 inferno = { version = "0.12", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
-soldb-bridge = { path = "../soldb-bridge" }
-soldb-compiler = { path = "../soldb-compiler" }
-soldb-core = { path = "../soldb-core" }
-soldb-debugger = { path = "../soldb-debugger" }
-soldb-ethdebug = { path = "../soldb-ethdebug" }
-soldb-profiler = { path = "../soldb-profiler" }
-soldb-repl = { path = "../soldb-repl" }
-soldb-rpc = { path = "../soldb-rpc" }
-soldb-serializer = { path = "../soldb-serializer" }
+soldb-bridge.workspace = true
+soldb-compiler.workspace = true
+soldb-core.workspace = true
+soldb-debugger.workspace = true
+soldb-ethdebug.workspace = true
+soldb-profiler.workspace = true
+soldb-repl.workspace = true
+soldb-rpc.workspace = true
+soldb-serializer.workspace = true
 
 [lints]
 workspace = true

--- a/crates/soldb-compiler/Cargo.toml
+++ b/crates/soldb-compiler/Cargo.toml
@@ -2,8 +2,13 @@
 name = "soldb-compiler"
 version.workspace = true
 edition.workspace = true
+description = "solc invocation, ETHDebug artifact discovery, and deploy helpers for SolDB"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 doctest = false
@@ -11,9 +16,9 @@ doctest = false
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-soldb-core = { path = "../soldb-core" }
-soldb-ethdebug = { path = "../soldb-ethdebug" }
-soldb-rpc = { path = "../soldb-rpc" }
+soldb-core.workspace = true
+soldb-ethdebug.workspace = true
+soldb-rpc.workspace = true
 
 [lints]
 workspace = true

--- a/crates/soldb-core/Cargo.toml
+++ b/crates/soldb-core/Cargo.toml
@@ -2,8 +2,13 @@
 name = "soldb-core"
 version.workspace = true
 edition.workspace = true
+description = "Shared trace, snapshot, capability, and error types for SolDB, the ETHDebug-first Solidity debugger"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 doctest = false

--- a/crates/soldb-dap/Cargo.toml
+++ b/crates/soldb-dap/Cargo.toml
@@ -2,8 +2,13 @@
 name = "soldb-dap"
 version.workspace = true
 edition.workspace = true
+description = "Debug Adapter Protocol server for SolDB, the ETHDebug-first Solidity debugger"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories = ["development-tools::debugging", "command-line-utilities"]
 
 [lib]
 doctest = false
@@ -11,11 +16,11 @@ doctest = false
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-soldb-core = { path = "../soldb-core" }
-soldb-debugger = { path = "../soldb-debugger" }
-soldb-ethdebug = { path = "../soldb-ethdebug" }
-soldb-repl = { path = "../soldb-repl" }
-soldb-rpc = { path = "../soldb-rpc" }
+soldb-core.workspace = true
+soldb-debugger.workspace = true
+soldb-ethdebug.workspace = true
+soldb-repl.workspace = true
+soldb-rpc.workspace = true
 
 [[bin]]
 name = "soldb-dap-server"

--- a/crates/soldb-debugger/Cargo.toml
+++ b/crates/soldb-debugger/Cargo.toml
@@ -2,8 +2,13 @@
 name = "soldb-debugger"
 version.workspace = true
 edition.workspace = true
+description = "Source-step, function, and variable decoding over SolDB transaction traces"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 doctest = false
@@ -11,8 +16,8 @@ doctest = false
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-soldb-core = { path = "../soldb-core" }
-soldb-ethdebug = { path = "../soldb-ethdebug" }
+soldb-core.workspace = true
+soldb-ethdebug.workspace = true
 
 [lints]
 workspace = true

--- a/crates/soldb-ethdebug/Cargo.toml
+++ b/crates/soldb-ethdebug/Cargo.toml
@@ -2,8 +2,13 @@
 name = "soldb-ethdebug"
 version.workspace = true
 edition.workspace = true
+description = "ETHDebug artifact loading, legacy source-map parsing, and ABI/event decoding for SolDB"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 doctest = false
@@ -12,7 +17,7 @@ doctest = false
 revm-bytecode = { version = "9.0", default-features = false, features = ["std"] }
 serde.workspace = true
 serde_json.workspace = true
-soldb-core = { path = "../soldb-core" }
+soldb-core.workspace = true
 
 [lints]
 workspace = true

--- a/crates/soldb-profiler/Cargo.toml
+++ b/crates/soldb-profiler/Cargo.toml
@@ -2,16 +2,21 @@
 name = "soldb-profiler"
 version.workspace = true
 edition.workspace = true
+description = "Gas attribution and folded-stack profiling over SolDB transaction traces"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 doctest = false
 
 [dependencies]
 serde.workspace = true
-soldb-core = { path = "../soldb-core" }
-soldb-ethdebug = { path = "../soldb-ethdebug" }
+soldb-core.workspace = true
+soldb-ethdebug.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/soldb-repl/Cargo.toml
+++ b/crates/soldb-repl/Cargo.toml
@@ -2,14 +2,19 @@
 name = "soldb-repl"
 version.workspace = true
 edition.workspace = true
+description = "Interactive debugger state machine (breakpoints, stepping, display modes) for SolDB"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 doctest = false
 
 [dependencies]
-soldb-core = { path = "../soldb-core" }
+soldb-core.workspace = true
 
 [lints]
 workspace = true

--- a/crates/soldb-rpc/Cargo.toml
+++ b/crates/soldb-rpc/Cargo.toml
@@ -2,8 +2,13 @@
 name = "soldb-rpc"
 version.workspace = true
 edition.workspace = true
+description = "JSON-RPC and REVM replay backends that produce SolDB transaction traces"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 doctest = false
@@ -11,7 +16,7 @@ doctest = false
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-soldb-core = { path = "../soldb-core" }
+soldb-core.workspace = true
 revm = { version = "36.0", default-features = false, features = [
     "std",
     "serde",

--- a/crates/soldb-serializer/Cargo.toml
+++ b/crates/soldb-serializer/Cargo.toml
@@ -2,8 +2,13 @@
 name = "soldb-serializer"
 version.workspace = true
 edition.workspace = true
+description = "Versioned JSON projection of SolDB traces and simulations for web clients"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 doctest = false
@@ -11,7 +16,7 @@ doctest = false
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-soldb-core = { path = "../soldb-core" }
+soldb-core.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

This PR prepares soldb for publishing on crates.io by versioning each sub-crates and renaming soldb-cli to soldb (so the installed binary shares the same name with the corresponding crate: `cargo install soldb` => `soldb --version`

## Testing done

N/A