### PR TITLE
docs: remove Telegram contact link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,4 +24,4 @@ Open an issue at https://github.com/walnuthq/soldb/issues.
 
 ## Questions
 
-Telegram: [@walnut_soldb](https://t.me/walnut_soldb) · Email: hi@walnut.dev
+Email: hi@walnut.dev

--- a/README.md
+++ b/README.md
@@ -342,5 +342,4 @@ dual-licensed the same way.
 📄 [GPL-3.0](./LICENSE.md) · [MIT](./LICENSE-MIT.md)
 
 ## Community & Support
-💬 Join our Telegram: [@walnut_soldb](https://t.me/walnut_soldb)
 📬 Email: hi@walnut.dev


### PR DESCRIPTION
The Telegram channel (@walnut_soldb) is not being used, so this removes the link from README.md and CONTRIBUTING.md. Email (hi@walnut.dev) stays as the primary contact to the team.