### PR TITLE
feat: automate crates.io release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+# Publishing a GitHub Release publishes the whole workspace to crates.io.
+#
+# The filename is load-bearing: crates.io trusted publishing authorizes this
+# repository *and this workflow filename* for each of the eleven crates.
+# Renaming the file breaks publishing until every trusted-publisher config is
+# updated to match.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: publish to crates.io
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # Required to exchange a GitHub OIDC token for a short-lived crates.io token.
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Check the tag matches the workspace version
+        run: |
+          version=$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "soldb") | .version')
+          tag="${GITHUB_REF_NAME#v}"
+          if [ "$version" != "$tag" ]; then
+            echo "tag \`$GITHUB_REF_NAME\` does not match workspace version \`$version\`" >&2
+            echo "bump the version in the workspace manifest, or retag the release" >&2
+            exit 1
+          fi
+
+      - name: Run tests
+        run: cargo test --workspace --all-targets
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      # `cargo publish --workspace` resolves the inter-crate publish order itself.
+      - name: Publish
+        run: cargo publish --workspace
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,24 @@ See [README.md](./README.md#development) for the full development setup, includi
 4. Run `cargo test --workspace --all-targets`
 5. Open a pull request — describe what you changed and why
 
+## Releasing
+
+Every crate in the workspace shares one version, and publishing a GitHub Release
+publishes all of them to crates.io via
+[`.github/workflows/release.yml`](./.github/workflows/release.yml).
+
+1. Bump the version. `cargo set-version --workspace 0.2.0` (from `cargo-edit`)
+   rewrites `[workspace.package]` and the `[workspace.dependencies]`
+   requirements together; pass `--dry-run` first to see the edits.
+2. Run `cargo check --workspace` so `Cargo.lock` picks up the new version, then
+   open a pull request with both files and merge it.
+3. Create a GitHub Release on `main` tagged `v0.2.0`. The tag must match the
+   workspace version — the workflow refuses to publish otherwise.
+4. Approve the `release` environment gate. All eleven crates publish together.
+
+Versions on crates.io are permanent: yanking hides a release from resolution but
+does not free the number.
+
 ## Reporting bugs
 
 Open an issue at https://github.com/walnuthq/soldb/issues.


### PR DESCRIPTION
## Summary

This PR adds a workflow to automatically publish all crates on crates.io when a new github release is published.

## Testing done

N/A