### PR TITLE
fix: remove hardcoded version 0.1.0 from tests

### DIFF
--- a/crates/soldb-cli/tests/trace_cli.rs
+++ b/crates/soldb-cli/tests/trace_cli.rs
@@ -40,7 +40,7 @@ fn help_and_version_are_served_by_rust_cli() {
         .expect("run soldb version");
     assert!(version.status.success());
     let stdout = String::from_utf8(version.stdout).expect("utf8 version");
-    assert!(stdout.contains("soldb 0.1.0"));
+    assert!(stdout.contains(concat!("soldb ", env!("CARGO_PKG_VERSION"))));
 }
 
 #[test]

--- a/test/cli/help.test
+++ b/test/cli/help.test
@@ -17,7 +17,7 @@
 # MAIN-DAG: profile
 # MAIN-DAG: simulate
 
-# VERSION: 0.1.0
+# VERSION: soldb {{[0-9]+\.[0-9]+\.[0-9]+}}
 
 # TRACE-DAG: Usage:
 # TRACE-DAG: TX_HASH


### PR DESCRIPTION
## Summary

Remove the hardcoded version 0.1.0 from tests.

## Testing done

Tests now pass with a soldb version different from 0.1.0