### PR TITLE
feat: compare compiler debug information

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ soldb profile <tx_hash> --backend replay \
 See [docs/profiling.md](docs/profiling.md) for captured traces, folded stacks,
 multi-contract attribution, and the reusable library API.
 
+Compare the source-level debugging experience of two compiler outputs:
+
+```bash
+soldb debug-diff \
+  --reference-tx <solc_tx_hash> \
+  --candidate-tx <candidate_tx_hash> \
+  --reference-ethdebug-dir <solc_address>:<contract>:<solc_out> \
+  --candidate-ethdebug-dir <candidate_address>:<contract>:<candidate_out> \
+  --rpc http://localhost:8545
+```
+
+See [docs/debug-diff.md](docs/debug-diff.md) for strict source-step, exact-span,
+and optimization-tolerant coverage comparisons.
+
 ---
 
 ## Example: Debugging a Transaction
@@ -171,6 +185,18 @@ See the [profiling guide](docs/profiling.md) for usage and integration details.
 
 ---
 
+## Debug Information Differentials
+
+`soldb debug-diff` executes a Dexter-style check of what a debugger observes.
+It maps two EVM traces through their compiler artifacts and compares normalized
+source steps instead of raw bytecode offsets. ETHDebug and legacy source maps
+can be compared in any combination.
+
+See the [debug-info differential guide](docs/debug-diff.md) for CI and offline
+usage.
+
+---
+
 ## Features
 
 - ETHDebug-first source debugging with legacy `srcmap`/`srcmap-runtime` fallback
@@ -184,6 +210,7 @@ See the [profiling guide](docs/profiling.md) for usage and integration details.
   naming stack words that may not be the parameters
 - Full transaction traces with internal calls & decoded parameters
 - Dynamic gas profiles by contract, function, source line, opcode, and instruction
+- Differential source-step, source-span, and coverage checks for compiler debug info
 - Folded-stack and interactive SVG flame graph output
 - Transaction simulation with arbitrary calldata (including structs & tuples), through
   `debug_traceCall` or replayed locally as a fork of the chain at any block and transaction index

--- a/crates/soldb-cli/src/debug_diff.rs
+++ b/crates/soldb-cli/src/debug_diff.rs
@@ -1,0 +1,336 @@
+//! Source-level debug-info differential command.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::{Args, ValueEnum};
+use soldb_core::{SoldbError, SoldbResult, TransactionTrace};
+use soldb_debugger::{
+    capture_debug_trace, compare_debug_traces, ContractDebugInfo, DebugDiffMode, DebugDiffReport,
+    DebugDifference, DebugTraceEvent,
+};
+use soldb_ethdebug::SourceMapEnvironment;
+
+use crate::{
+    bold, dim, error_color, function_color, info, number_color, print_json,
+    print_json_command_error, resolve_contract_specs, success, TraceBackendArg, TraceSourceIndex,
+};
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum DebugDiffModeArg {
+    Steps,
+    Spans,
+    Coverage,
+}
+
+impl From<DebugDiffModeArg> for DebugDiffMode {
+    fn from(value: DebugDiffModeArg) -> Self {
+        match value {
+            DebugDiffModeArg::Steps => Self::Steps,
+            DebugDiffModeArg::Spans => Self::Spans,
+            DebugDiffModeArg::Coverage => Self::Coverage,
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct DebugDiffArgs {
+    /// A serialized reference `TransactionTrace`.
+    #[arg(
+        long,
+        value_name = "PATH",
+        required_unless_present = "reference_tx",
+        conflicts_with = "reference_tx"
+    )]
+    reference_trace_file: Option<PathBuf>,
+    /// Reference transaction hash to trace through `--rpc`.
+    #[arg(
+        long,
+        value_name = "HASH",
+        required_unless_present = "reference_trace_file",
+        conflicts_with = "reference_trace_file"
+    )]
+    reference_tx: Option<String>,
+    /// A serialized candidate `TransactionTrace`.
+    #[arg(
+        long,
+        value_name = "PATH",
+        required_unless_present = "candidate_tx",
+        conflicts_with = "candidate_tx"
+    )]
+    candidate_trace_file: Option<PathBuf>,
+    /// Candidate transaction hash to trace through `--rpc`.
+    #[arg(
+        long,
+        value_name = "HASH",
+        required_unless_present = "candidate_trace_file",
+        conflicts_with = "candidate_trace_file"
+    )]
+    candidate_tx: Option<String>,
+    /// Trace backend used for transaction hashes.
+    #[arg(long, value_enum, default_value_t = TraceBackendArg::Replay)]
+    backend: TraceBackendArg,
+    /// RPC endpoint used for transaction hashes.
+    #[arg(long, default_value = "http://localhost:8545")]
+    rpc: String,
+    /// Reference artifact as `<address>:<contract>:<dir>`. Repeatable.
+    #[arg(long = "reference-ethdebug-dir", value_name = "SPEC")]
+    reference_ethdebug_dir: Vec<String>,
+    /// Root for sources named by reference artifacts. Repeatable.
+    #[arg(long = "reference-source-path", value_name = "PATH")]
+    reference_source_path: Vec<String>,
+    /// Reference multi-contract mapping file.
+    #[arg(long = "reference-contracts", value_name = "PATH")]
+    reference_contracts: Option<String>,
+    /// Candidate artifact as `<address>:<contract>:<dir>`. Repeatable.
+    #[arg(long = "candidate-ethdebug-dir", value_name = "SPEC")]
+    candidate_ethdebug_dir: Vec<String>,
+    /// Root for sources named by candidate artifacts. Repeatable.
+    #[arg(long = "candidate-source-path", value_name = "PATH")]
+    candidate_source_path: Vec<String>,
+    /// Candidate multi-contract mapping file.
+    #[arg(long = "candidate-contracts", value_name = "PATH")]
+    candidate_contracts: Option<String>,
+    /// Compare ordered steps, exact spans, or reached source coverage.
+    #[arg(long, value_enum, default_value_t = DebugDiffModeArg::Steps)]
+    mode: DebugDiffModeArg,
+    /// Maximum number of differences included in the report.
+    #[arg(long, default_value_t = 8)]
+    max_differences: usize,
+    /// Emit one machine-readable report.
+    #[arg(long)]
+    json: bool,
+}
+
+pub(crate) fn command(args: &DebugDiffArgs) -> SoldbResult<()> {
+    match command_inner(args) {
+        Err(SoldbError::AlreadyReported) => Err(SoldbError::AlreadyReported),
+        Err(error) if args.json => {
+            print_json_command_error("DebugDiffError", &error.to_string(), None)?;
+            Err(SoldbError::AlreadyReported)
+        }
+        result => result,
+    }
+}
+
+fn command_inner(args: &DebugDiffArgs) -> SoldbResult<()> {
+    let reference_trace = load_trace(
+        "reference",
+        args.reference_trace_file.as_deref(),
+        args.reference_tx.as_deref(),
+        &args.rpc,
+        args.backend,
+    )?;
+    let candidate_trace = load_trace(
+        "candidate",
+        args.candidate_trace_file.as_deref(),
+        args.candidate_tx.as_deref(),
+        &args.rpc,
+        args.backend,
+    )?;
+    let reference_contracts = load_contracts(
+        "reference",
+        &reference_trace,
+        &args.reference_ethdebug_dir,
+        args.reference_contracts.as_deref(),
+        &args.reference_source_path,
+    )?;
+    let candidate_contracts = load_contracts(
+        "candidate",
+        &candidate_trace,
+        &args.candidate_ethdebug_dir,
+        args.candidate_contracts.as_deref(),
+        &args.candidate_source_path,
+    )?;
+    let reference = capture_debug_trace(&reference_trace, reference_contracts);
+    let candidate = capture_debug_trace(&candidate_trace, candidate_contracts);
+    let report = compare_debug_traces(
+        &reference,
+        &candidate,
+        args.mode.into(),
+        args.max_differences,
+    );
+
+    if args.json {
+        print_json(&report)?;
+    } else {
+        print_report(&report);
+    }
+    if report.equivalent {
+        Ok(())
+    } else {
+        Err(SoldbError::AlreadyReported)
+    }
+}
+
+fn load_trace(
+    side: &str,
+    path: Option<&Path>,
+    tx_hash: Option<&str>,
+    rpc: &str,
+    backend: TraceBackendArg,
+) -> SoldbResult<TransactionTrace> {
+    if let Some(path) = path {
+        let input = fs::read_to_string(path).map_err(|error| {
+            SoldbError::Message(format!(
+                "failed to read {side} trace file `{}`: {error}",
+                path.display()
+            ))
+        })?;
+        return serde_json::from_str(&input).map_err(|error| {
+            SoldbError::Message(format!(
+                "invalid transaction trace in `{}`: {error}",
+                path.display()
+            ))
+        });
+    }
+
+    let Some(tx_hash) = tx_hash else {
+        return Err(SoldbError::Message(format!(
+            "debug diff requires a {side} transaction or trace file"
+        )));
+    };
+    soldb_rpc::trace_transaction_with_resolved_backend(rpc, tx_hash, backend.into())
+        .map(|resolved| resolved.trace)
+}
+
+fn load_contracts(
+    side: &str,
+    trace: &TransactionTrace,
+    ethdebug_dirs: &[String],
+    contracts_file: Option<&str>,
+    source_paths: &[String],
+) -> SoldbResult<Vec<ContractDebugInfo>> {
+    let specs = resolve_contract_specs(ethdebug_dirs, contracts_file, source_paths)?;
+    if specs.is_empty() {
+        return Err(SoldbError::Message(format!(
+            "no {side} debug artifacts provided; use `--{side}-ethdebug-dir` or \
+             `--{side}-contracts`"
+        )));
+    }
+    let environment = if trace.to_addr.is_some() {
+        SourceMapEnvironment::Runtime
+    } else {
+        SourceMapEnvironment::Creation
+    };
+
+    specs
+        .iter()
+        .map(|spec| {
+            TraceSourceIndex::load_environment(spec, environment)?
+                .map(|index| index.debug)
+                .ok_or_else(|| {
+                    SoldbError::Message(format!(
+                        "no {side} {} debug program for `{}` found in `{}`",
+                        environment_name(environment),
+                        spec.name,
+                        spec.debug_dir.display()
+                    ))
+                })
+        })
+        .collect()
+}
+
+fn environment_name(environment: SourceMapEnvironment) -> &'static str {
+    match environment {
+        SourceMapEnvironment::Creation => "creation",
+        SourceMapEnvironment::Runtime => "runtime",
+    }
+}
+
+fn print_report(report: &DebugDiffReport) {
+    println!("{}", bold(info("Debug Info Differential")));
+    println!("{} {:?}", info("Mode:"), report.mode);
+    print_summary("Reference", &report.reference);
+    print_summary("Candidate", &report.candidate);
+    if !report.execution_equivalent {
+        println!("{}", error_color("Execution differs:"));
+        for difference in &report.execution_differences {
+            println!("  - {difference}");
+        }
+    }
+    for diagnostic in &report.diagnostics {
+        println!("{} {diagnostic}", error_color("Unavailable:"));
+    }
+    if report.equivalent {
+        println!("{} {}", info("Result:"), success("MATCH"));
+        return;
+    }
+
+    println!("{} {}", info("Result:"), error_color("DIFFERENT"));
+    println!(
+        "{} {}",
+        info("Source differences:"),
+        number_color(report.difference_count)
+    );
+    for difference in &report.differences {
+        print_difference(difference);
+    }
+    if report.differences_truncated {
+        println!("{}", dim("additional differences omitted"));
+    }
+}
+
+fn print_summary(label: &str, summary: &soldb_debugger::DebugTraceSummary) {
+    println!(
+        "{} {} source steps; {}/{} instructions mapped; {} frame entries",
+        info(format!("{label}:")),
+        number_color(summary.source_steps),
+        number_color(summary.mapped_instructions),
+        number_color(summary.instructions),
+        number_color(summary.frame_entries)
+    );
+}
+
+fn print_difference(difference: &DebugDifference) {
+    println!(
+        "{} {}",
+        error_color(format!("{:?}", difference.kind)),
+        dim(format!("at source step {}", difference.index))
+    );
+    if let Some(event) = &difference.reference {
+        println!("  {} {}", info("reference:"), format_event(event));
+    }
+    if let Some(event) = &difference.candidate {
+        println!("  {} {}", info("candidate:"), format_event(event));
+    }
+}
+
+fn format_event(event: &DebugTraceEvent) -> String {
+    let function = event.function.as_deref().unwrap_or("<contract>");
+    format!(
+        "{}:{}:{} in {}::{} at depth {} (instruction {}, pc {})",
+        event.source,
+        event.line,
+        event.column,
+        event.contract,
+        function_color(function),
+        event.frame_depth,
+        event.instruction,
+        event.pc
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::load_trace;
+    use crate::TraceBackendArg;
+
+    #[test]
+    fn invalid_trace_file_names_the_side() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("soldb-debug-diff-{unique}.json"));
+        fs::write(&path, "not json").expect("write trace");
+
+        let error = load_trace("candidate", Some(&path), None, "", TraceBackendArg::Replay)
+            .expect_err("invalid trace");
+
+        assert!(error.to_string().contains("invalid transaction trace"));
+    }
+}

--- a/crates/soldb-cli/src/debug_diff.rs
+++ b/crates/soldb-cli/src/debug_diff.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use clap::{Args, ValueEnum};
 use soldb_core::{SoldbError, SoldbResult, TransactionTrace};
 use soldb_debugger::{
-    capture_debug_trace, compare_debug_traces, ContractDebugInfo, DebugDiffMode, DebugDiffReport,
-    DebugDifference, DebugTraceEvent,
+    capture_debug_trace, compare_debug_traces, ContractDebugInfo, DebugCheckpoint, DebugDiffMode,
+    DebugDiffReport, DebugDifference, DebugTraceEvent,
 };
 use soldb_ethdebug::SourceMapEnvironment;
 
@@ -91,6 +91,15 @@ pub(crate) struct DebugDiffArgs {
     /// Candidate multi-contract mapping file.
     #[arg(long = "candidate-contracts", value_name = "PATH")]
     candidate_contracts: Option<String>,
+    /// Encoded reference constructor arguments, including `0x` for no arguments.
+    #[arg(long, value_name = "HEX")]
+    reference_constructor_args: Option<String>,
+    /// Encoded candidate constructor arguments, including `0x` for no arguments.
+    #[arg(long, value_name = "HEX")]
+    candidate_constructor_args: Option<String>,
+    /// JSON source/line checkpoints that both executions must reach.
+    #[arg(long, value_name = "PATH")]
+    checkpoints_file: Option<PathBuf>,
     /// Compare ordered steps, exact spans, or reached source coverage.
     #[arg(long, value_enum, default_value_t = DebugDiffModeArg::Steps)]
     mode: DebugDiffModeArg,
@@ -142,8 +151,28 @@ fn command_inner(args: &DebugDiffArgs) -> SoldbResult<()> {
         args.candidate_contracts.as_deref(),
         &args.candidate_source_path,
     )?;
-    let reference = capture_debug_trace(&reference_trace, reference_contracts);
-    let candidate = capture_debug_trace(&candidate_trace, candidate_contracts);
+    let mut reference = capture_debug_trace(&reference_trace, reference_contracts);
+    let mut candidate = capture_debug_trace(&candidate_trace, candidate_contracts);
+    if let Some(arguments) = &args.reference_constructor_args {
+        reference.set_constructor_args(arguments)?;
+    }
+    if let Some(arguments) = &args.candidate_constructor_args {
+        candidate.set_constructor_args(arguments)?;
+    }
+    if let Some(path) = &args.checkpoints_file {
+        let contents = fs::read_to_string(path).map_err(|error| {
+            SoldbError::Message(format!(
+                "failed to read checkpoints `{}`: {error}",
+                path.display()
+            ))
+        })?;
+        let checkpoints =
+            serde_json::from_str::<Vec<DebugCheckpoint>>(&contents).map_err(|error| {
+                SoldbError::Message(format!("invalid checkpoints `{}`: {error}", path.display()))
+            })?;
+        reference.retain_checkpoints(&checkpoints);
+        candidate.retain_checkpoints(&checkpoints);
+    }
     let report = compare_debug_traces(
         &reference,
         &candidate,

--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -18,6 +18,7 @@
 //!   [`soldb_core::SoldbError::AlreadyReported`] so the exit path does not print it
 //!   twice. Failures exit with code 2.
 
+mod debug_diff;
 mod profile;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
@@ -46,6 +47,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::{Mutex, OnceLock};
 
+use debug_diff::DebugDiffArgs;
 use profile::ProfileArgs;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -178,6 +180,8 @@ enum Command {
     Bridge(BridgeArgs),
     #[command(about = "Compile Solidity contracts with ETHDebug artifacts")]
     Compile(CompileArgs),
+    #[command(about = "Compare two source-level debugging experiences")]
+    DebugDiff(DebugDiffArgs),
     #[command(about = "Inspect compiler debug metadata")]
     Info(InfoArgs),
     #[command(name = "list-contracts", about = "List all contracts in the project")]
@@ -722,6 +726,7 @@ fn main() -> ExitCode {
     let result = match cli.command {
         Command::Trace(args) => trace_command(&args),
         Command::Replay(args) => replay_command(&args),
+        Command::DebugDiff(args) => debug_diff::command(&args),
         Command::Profile(args) => profile::command(&args),
         Command::Simulate(args) => simulate_command(&args),
         Command::Run(args) => run_command(&args),

--- a/crates/soldb-cli/src/main.rs
+++ b/crates/soldb-cli/src/main.rs
@@ -571,6 +571,9 @@ struct RunArgs {
     /// unless `--runtime`; it is deployed locally first, so the constructor's state is
     /// what the call sees.
     bytecode: String,
+    /// Save the complete TransactionTrace for offline debug-diff and profiling.
+    #[arg(long, value_name = "FILE")]
+    save_trace: Option<PathBuf>,
     function_signature: Option<String>,
     function_args: Vec<String>,
     /// The caller. Defaults to the first Anvil account, so a deployment lands at the
@@ -1338,6 +1341,7 @@ fn run_command(args: &RunArgs) -> SoldbResult<()> {
         })?;
         let trace = chain.deploy(deployment)?;
         let calldata = deployment.input_data.clone();
+        save_run_trace(args, &trace)?;
         return present_simulation(&view, trace, contract_name.as_deref(), &calldata);
     }
 
@@ -1358,7 +1362,22 @@ fn run_command(args: &RunArgs) -> SoldbResult<()> {
             "the call executed no instructions; there is no code at `{contract_address}`\nnote: pass creation code, or `--runtime` with the deployed code"
         )));
     }
+    save_run_trace(args, &trace)?;
     present_simulation(&view, trace, contract_name.as_deref(), &calldata)
+}
+
+/// Writes the raw trace format used by offline consumers, independently of display mode.
+fn save_run_trace(args: &RunArgs, trace: &TransactionTrace) -> SoldbResult<()> {
+    if let Some(path) = &args.save_trace {
+        let output = soldb_serializer::trace_to_json(trace)?;
+        fs::write(path, output).map_err(|error| {
+            soldb_core::SoldbError::Message(format!(
+                "failed to save trace `{}`: {error}",
+                path.display()
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 /// Reads bytecode from a file when `source` names one, otherwise treats it as hex.

--- a/crates/soldb-cli/tests/trace_cli.rs
+++ b/crates/soldb-cli/tests/trace_cli.rs
@@ -46,7 +46,7 @@ fn help_and_version_are_served_by_rust_cli() {
 
 #[test]
 fn debug_diff_compares_source_level_traces() {
-    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/profile");
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/debug-diff");
     let trace = fixture.join("trace.json");
     let spec = format!(
         "0x000000000000000000000000000000000000cafe:Counter:{}",
@@ -83,7 +83,7 @@ fn debug_diff_compares_source_level_traces() {
 
 #[test]
 fn debug_diff_fails_when_the_candidate_loses_source_steps() {
-    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/profile");
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/debug-diff");
     let reference_trace = fixture.join("trace.json");
     let trace = fs::read_to_string(&reference_trace).expect("read trace");
     let mut candidate = serde_json::from_str::<serde_json::Value>(&trace).expect("trace JSON");
@@ -124,7 +124,7 @@ fn debug_diff_fails_when_the_candidate_loses_source_steps() {
 
 #[test]
 fn debug_diff_compares_ethdebug_with_legacy_maps() {
-    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/profile");
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/debug-diff");
     let trace = fixture.join("trace.json");
     let legacy = temp_dir("debug-diff-legacy");
     let source =
@@ -178,6 +178,37 @@ fn debug_diff_compares_ethdebug_with_legacy_maps() {
     );
     let report: serde_json::Value = serde_json::from_slice(&output.stdout).expect("diff JSON");
     assert_eq!(report["equivalent"], true);
+}
+
+#[test]
+fn run_exports_a_trace_that_debug_diff_can_read() {
+    let dir = temp_dir("run-save-trace");
+    let path = dir.join("trace.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_soldb"))
+        .args([
+            "run",
+            "600160005260206000f3",
+            "--runtime",
+            "--raw-data",
+            "0x",
+            "--json",
+            "--save-trace",
+        ])
+        .arg(&path)
+        .output()
+        .expect("run runtime code");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let trace = serde_json::from_slice::<soldb_core::TransactionTrace>(
+        &fs::read(&path).expect("saved trace"),
+    )
+    .expect("raw transaction trace");
+    assert!(trace.success);
+    assert!(!trace.steps.is_empty());
+    assert!(trace.output.ends_with("01"));
 }
 
 #[test]

--- a/crates/soldb-cli/tests/trace_cli.rs
+++ b/crates/soldb-cli/tests/trace_cli.rs
@@ -30,6 +30,7 @@ fn help_and_version_are_served_by_rust_cli() {
     let stdout = String::from_utf8(help.stdout).expect("utf8 help");
     assert!(stdout.contains("SolDB - Ethereum transaction analysis tool"));
     assert!(stdout.contains("trace"));
+    assert!(stdout.contains("debug-diff"));
     assert!(stdout.contains("profile"));
     assert!(stdout.contains("simulate"));
     assert!(stdout.contains("list-events"));
@@ -41,6 +42,142 @@ fn help_and_version_are_served_by_rust_cli() {
     assert!(version.status.success());
     let stdout = String::from_utf8(version.stdout).expect("utf8 version");
     assert!(stdout.contains(concat!("soldb ", env!("CARGO_PKG_VERSION"))));
+}
+
+#[test]
+fn debug_diff_compares_source_level_traces() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/profile");
+    let trace = fixture.join("trace.json");
+    let spec = format!(
+        "0x000000000000000000000000000000000000cafe:Counter:{}",
+        fixture.display()
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldb"))
+        .args([
+            "debug-diff",
+            "--reference-trace-file",
+            trace.to_str().expect("trace path"),
+            "--candidate-trace-file",
+            trace.to_str().expect("trace path"),
+            "--reference-ethdebug-dir",
+            &spec,
+            "--candidate-ethdebug-dir",
+            &spec,
+            "--json",
+        ])
+        .output()
+        .expect("run debug diff");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).expect("diff JSON");
+    assert_eq!(report["schemaVersion"], 1);
+    assert_eq!(report["equivalent"], true);
+    assert_eq!(report["differenceCount"], 0);
+    assert_eq!(report["reference"]["sourceSteps"], 1);
+}
+
+#[test]
+fn debug_diff_fails_when_the_candidate_loses_source_steps() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/profile");
+    let reference_trace = fixture.join("trace.json");
+    let trace = fs::read_to_string(&reference_trace).expect("read trace");
+    let mut candidate = serde_json::from_str::<serde_json::Value>(&trace).expect("trace JSON");
+    for step in candidate["steps"].as_array_mut().expect("trace steps") {
+        step["pc"] = json!(99);
+    }
+    let dir = temp_dir("debug-diff");
+    let candidate_trace = dir.join("candidate.json");
+    fs::write(&candidate_trace, candidate.to_string()).expect("write candidate trace");
+    let spec = format!(
+        "0x000000000000000000000000000000000000cafe:Counter:{}",
+        fixture.display()
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldb"))
+        .args([
+            "debug-diff",
+            "--reference-trace-file",
+            reference_trace.to_str().expect("trace path"),
+            "--candidate-trace-file",
+            candidate_trace.to_str().expect("candidate path"),
+            "--reference-ethdebug-dir",
+            &spec,
+            "--candidate-ethdebug-dir",
+            &spec,
+            "--json",
+        ])
+        .output()
+        .expect("run debug diff");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stderr.is_empty());
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).expect("diff JSON");
+    assert_eq!(report["equivalent"], false);
+    assert_eq!(report["differenceCount"], 1);
+    assert_eq!(report["differences"][0]["kind"], "missing");
+}
+
+#[test]
+fn debug_diff_compares_ethdebug_with_legacy_maps() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test/fixtures/profile");
+    let trace = fixture.join("trace.json");
+    let legacy = temp_dir("debug-diff-legacy");
+    let source =
+        "contract Counter {\n    function add() external {\n        uint256 x = 1;\n    }\n}\n";
+    fs::write(legacy.join("Counter.sol"), source).expect("write source");
+    fs::write(
+        legacy.join("combined.json"),
+        json!({
+            "version": "0.8.16+commit.test",
+            "sourceList": ["Counter.sol"],
+            "contracts": {
+                "Counter.sol:Counter": {
+                    "bin-runtime": "600101",
+                    "srcmap-runtime": "57:13:0:i:0;57:13:0:-:0"
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write combined JSON");
+    let reference_spec = format!(
+        "0x000000000000000000000000000000000000cafe:Counter:{}",
+        fixture.display()
+    );
+    let candidate_spec = format!(
+        "0x000000000000000000000000000000000000cafe:Counter:{}",
+        legacy.display()
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soldb"))
+        .args([
+            "debug-diff",
+            "--reference-trace-file",
+            trace.to_str().expect("trace path"),
+            "--candidate-trace-file",
+            trace.to_str().expect("trace path"),
+            "--reference-ethdebug-dir",
+            &reference_spec,
+            "--candidate-ethdebug-dir",
+            &candidate_spec,
+            "--json",
+        ])
+        .output()
+        .expect("run debug diff");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).expect("diff JSON");
+    assert_eq!(report["equivalent"], true);
 }
 
 #[test]

--- a/crates/soldb-debugger/src/debug_diff.rs
+++ b/crates/soldb-debugger/src/debug_diff.rs
@@ -2,17 +2,19 @@
 //!
 //! Compilers need not emit the same bytecode for the same source, so comparing raw
 //! source maps or program counters says little about what a user sees. This module maps
-//! each execution through [`StepMap`], records the source stops exposed by `step`, and
-//! compares those normalized traces. The result is suitable for a test harness: it is
+//! each execution through [`StepMap::for_debug_diff`], keeping single-instruction
+//! source stops that interactive stepping can smooth over, and compares the traces.
+//! The result is suitable for a test harness: it is
 //! deterministic, serializable, and separates execution differences from debug-info
 //! differences.
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
-use soldb_core::TransactionTrace;
+use soldb_core::{SoldbError, SoldbResult, TransactionTrace};
+use soldb_ethdebug::{keccak256, parse_word, word_hex};
 
-use crate::{source_path_matches, ContractDebugInfo, StepMap};
+use crate::{ContractDebugInfo, StepMap};
 
 /// How strictly two source-level traces are compared.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -35,6 +37,9 @@ pub struct DebugExecution {
     pub value: String,
     pub success: bool,
     pub output: String,
+    /// ABI-encoded arguments supplied separately from compiler-specific initcode.
+    #[serde(default)]
+    pub constructor_args: Option<String>,
 }
 
 /// Aggregate mapping quality for one side of a comparison.
@@ -47,7 +52,7 @@ pub struct DebugTraceSummary {
     pub frame_entries: usize,
 }
 
-/// One user-visible source stop in an execution.
+/// One compiler-mapped source stop in an execution.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DebugTraceEvent {
@@ -57,6 +62,9 @@ pub struct DebugTraceEvent {
     pub pc: u64,
     pub contract: String,
     pub source: String,
+    /// Keccak-256 of the exact source bytes, independent of checkout location.
+    #[serde(default)]
+    pub source_hash: Option<[u8; 32]>,
     pub line: u64,
     pub column: u64,
     pub offset: u64,
@@ -76,6 +84,73 @@ pub struct DebugTrace {
     pub execution: DebugExecution,
     pub summary: DebugTraceSummary,
     pub events: Vec<DebugTraceEvent>,
+    /// Artifact or trace inconsistencies that make a comparison inconclusive.
+    #[serde(default)]
+    pub diagnostics: Vec<String>,
+}
+
+/// A source stop required by a test, independent of compiler-generated entry steps.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DebugCheckpoint {
+    pub source: String,
+    /// One-based source line.
+    pub line: u64,
+}
+
+impl DebugTrace {
+    /// Restricts comparison to explicit test checkpoints and diagnoses unreached ones.
+    ///
+    /// This is a test expectation, not source recovery: only existing mapped stops can
+    /// satisfy a checkpoint. Each side must reach every checkpoint at least once.
+    pub fn retain_checkpoints(&mut self, checkpoints: &[DebugCheckpoint]) {
+        let mut by_line = BTreeMap::<u64, Vec<(usize, String)>>::new();
+        for (index, checkpoint) in checkpoints.iter().enumerate() {
+            by_line
+                .entry(checkpoint.line)
+                .or_default()
+                .push((index, normalize_source_path(&checkpoint.source)));
+        }
+        let mut reached = BTreeSet::new();
+        self.events.retain(|event| {
+            let mut matched = false;
+            for (index, source) in by_line.get(&event.line).into_iter().flatten() {
+                if source_paths_match(&event.source, source) {
+                    reached.insert(*index);
+                    matched = true;
+                }
+            }
+            matched
+        });
+        for (index, checkpoint) in checkpoints.iter().enumerate() {
+            if !reached.contains(&index) {
+                self.diagnostics.push(format!(
+                    "checkpoint {}:{} was not reached",
+                    checkpoint.source, checkpoint.line
+                ));
+            }
+        }
+        self.summary.source_steps = self.events.len();
+    }
+
+    /// Supplies encoded constructor arguments when comparing creation executions.
+    ///
+    /// Their boundary cannot be recovered from source maps: initcode contains embedded
+    /// runtime code and data too. The caller must supply the known ABI payload.
+    pub fn set_constructor_args(&mut self, arguments: &str) -> SoldbResult<()> {
+        let arguments = normalize_hex_data(arguments);
+        let hex = arguments.strip_prefix("0x").unwrap_or(&arguments);
+        if !self.execution.creation
+            || !hex.len().is_multiple_of(2)
+            || !hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+            || !self.execution.input.ends_with(hex)
+        {
+            return Err(SoldbError::Message(
+                "constructor arguments must be hex matching the end of creation input".to_owned(),
+            ));
+        }
+        self.execution.constructor_args = Some(arguments);
+        Ok(())
+    }
 }
 
 /// The kind of one sampled difference.
@@ -117,18 +192,74 @@ pub struct DebugDiffReport {
     pub differences_truncated: bool,
 }
 
-/// Maps one execution to the source stops a debugger exposes.
+/// Maps one execution to source stops without interactive line smoothing.
 #[must_use]
 pub fn capture_debug_trace(
     trace: &TransactionTrace,
     contracts: Vec<ContractDebugInfo>,
 ) -> DebugTrace {
-    let map = StepMap::new(trace, contracts);
+    let mut diagnostics = BTreeSet::new();
+    let source_hashes = contracts
+        .iter()
+        .enumerate()
+        .flat_map(|(index, contract)| {
+            contract
+                .source_contents
+                .iter()
+                .map(move |(source, content)| ((index, *source), keccak256(content.as_bytes())))
+        })
+        .collect::<BTreeMap<_, _>>();
+    for contract in &contracts {
+        let mut pcs = BTreeSet::new();
+        for instruction in &contract.info.instructions {
+            if !pcs.insert(instruction.offset) {
+                diagnostics.insert(format!(
+                    "duplicate instruction at PC {} in `{}`",
+                    instruction.offset, contract.name
+                ));
+            }
+            for source in instruction.source_locations() {
+                let valid = contract
+                    .source_contents
+                    .get(&source.source_id)
+                    .is_some_and(|text| {
+                        source
+                            .offset
+                            .checked_add(source.length)
+                            .is_some_and(|end| end <= text.len() as u64)
+                    });
+                if !valid {
+                    diagnostics.insert(format!(
+                        "missing source or invalid source range at PC {} in `{}`",
+                        instruction.offset, contract.name
+                    ));
+                }
+            }
+        }
+    }
+    let map = StepMap::for_debug_diff(trace, contracts);
     let mut mapped_instructions = 0;
     let mut frame_entries = 0;
     let mut events = Vec::new();
 
     for instruction in 0..map.step_count() {
+        let step = &trace.steps[instruction];
+        if let Some(contract) = map.contract_at_step(instruction) {
+            let opcode = contract
+                .instruction_at_pc(step.pc)
+                .and_then(|inst| inst.mnemonic());
+            if !opcode.is_some_and(|opcode| opcodes_match(opcode, &step.op)) {
+                diagnostics.insert(format!(
+                    "trace opcode `{}` at PC {} disagrees with artifact `{}` in `{}`",
+                    step.op,
+                    step.pc,
+                    opcode.unwrap_or("<missing>"),
+                    contract.name
+                ));
+            }
+        } else {
+            diagnostics.insert("trace has steps without a matching contract artifact".to_owned());
+        }
         if map.line_key(instruction).is_some() {
             mapped_instructions += 1;
         }
@@ -142,9 +273,6 @@ pub fn capture_debug_trace(
         let Some(location) = map.location(instruction) else {
             continue;
         };
-        let Some(step) = trace.steps.get(instruction) else {
-            continue;
-        };
         let modifier_depth = map
             .contract_at_step(instruction)
             .and_then(|contract| contract.modifier_depth_at_pc(step.pc));
@@ -153,6 +281,9 @@ pub fn capture_debug_trace(
             pc: step.pc,
             contract: location.contract_name,
             source: normalize_source_path(&location.path),
+            source_hash: source_hashes
+                .get(&(location.key.contract, location.key.source_id))
+                .copied(),
             line: location.line,
             column: location.column,
             offset: location.offset,
@@ -169,9 +300,16 @@ pub fn capture_debug_trace(
         execution: DebugExecution {
             creation: trace.to_addr.is_none(),
             input: normalize_hex_data(&trace.input_data),
-            value: normalize_quantity(&trace.value),
+            value: match parse_word(&trace.value) {
+                Ok(value) => word_hex(&value),
+                Err(error) => {
+                    diagnostics.insert(format!("invalid call value: {error}"));
+                    trace.value.clone()
+                }
+            },
             success: trace.success,
             output: normalize_hex_data(&trace.output),
+            constructor_args: None,
         },
         summary: DebugTraceSummary {
             instructions: map.step_count(),
@@ -180,6 +318,7 @@ pub fn capture_debug_trace(
             frame_entries,
         },
         events,
+        diagnostics: diagnostics.into_iter().collect(),
     }
 }
 
@@ -193,6 +332,17 @@ pub fn compare_debug_traces(
     difference_limit: usize,
 ) -> DebugDiffReport {
     let mut diagnostics = Vec::new();
+    for (side, trace) in [("reference", reference), ("candidate", candidate)] {
+        diagnostics.extend(
+            trace
+                .diagnostics
+                .iter()
+                .map(|message| format!("{side}: {message}")),
+        );
+        if trace.events.iter().any(|event| event.source_hash.is_none()) {
+            diagnostics.push(format!("{side}: source identity is unavailable"));
+        }
+    }
     if reference.events.is_empty() {
         diagnostics.push("reference trace has no source steps".to_owned());
     }
@@ -232,7 +382,15 @@ fn compare_execution(reference: &DebugExecution, candidate: &DebugExecution) -> 
     if reference.creation != candidate.creation {
         differences.push("execution kind differs".to_owned());
     }
-    if reference.input != candidate.input {
+    if reference.creation && candidate.creation {
+        match (&reference.constructor_args, &candidate.constructor_args) {
+            (Some(left), Some(right)) if left != right => {
+                differences.push("constructor arguments differ".to_owned());
+            }
+            (Some(_), Some(_)) => {}
+            _ => differences.push("encoded constructor arguments were not supplied".to_owned()),
+        }
+    } else if reference.input != candidate.input {
         differences.push("calldata differs".to_owned());
     }
     if reference.value != candidate.value {
@@ -243,7 +401,9 @@ fn compare_execution(reference: &DebugExecution, candidate: &DebugExecution) -> 
     }
     // Creation returns compiler-specific runtime bytecode, so differing output is not a
     // behavioral mismatch between the constructors.
-    if !reference.creation && !candidate.creation && reference.output != candidate.output {
+    let deployed =
+        reference.creation && candidate.creation && reference.success && candidate.success;
+    if !deployed && reference.output != candidate.output {
         differences.push("return data differs".to_owned());
     }
     differences
@@ -309,8 +469,9 @@ fn compare_coverage(
             .find_map(|candidate_index| {
                 let right = candidate[*candidate_index];
                 (!matched_candidate.contains(candidate_index)
-                    && source_path_matches(&left.source, &right.source))
-                .then_some((*candidate_index, right))
+                    && source_paths_match(&left.source, &right.source)
+                    && left.source_hash == right.source_hash)
+                    .then_some((*candidate_index, right))
             });
         if let Some((candidate_index, _)) = right {
             matched_candidate.insert(candidate_index);
@@ -349,7 +510,13 @@ fn unique_coverage(events: &[DebugTraceEvent]) -> Vec<&DebugTraceEvent> {
     let mut keys = BTreeSet::new();
     let mut unique = Vec::new();
     for event in events {
-        if keys.insert((&event.contract, &event.source, event.line, &event.function)) {
+        if keys.insert((
+            &event.contract,
+            &event.source,
+            event.source_hash,
+            event.line,
+            &event.function,
+        )) {
             unique.push(event);
         }
     }
@@ -379,7 +546,8 @@ fn events_match(
     mode: DebugDiffMode,
 ) -> bool {
     let source_step = reference.contract == candidate.contract
-        && source_path_matches(&reference.source, &candidate.source)
+        && source_paths_match(&reference.source, &candidate.source)
+        && reference.source_hash == candidate.source_hash
         && reference.line == candidate.line
         && reference.function == candidate.function;
     if mode == DebugDiffMode::Coverage {
@@ -410,20 +578,23 @@ fn normalize_hex_data(value: &str) -> String {
     format!("0x{}", value.to_ascii_lowercase())
 }
 
-fn normalize_quantity(value: &str) -> String {
-    if let Some(value) = value
-        .strip_prefix("0x")
-        .or_else(|| value.strip_prefix("0X"))
-    {
-        let value = value.trim_start_matches('0');
-        return format!("0x{}", if value.is_empty() { "0" } else { value });
-    }
-    let value = value.trim_start_matches('0');
-    if value.is_empty() {
-        "0".to_owned()
-    } else {
-        value.to_owned()
-    }
+fn source_paths_match(left: &str, right: &str) -> bool {
+    let absolute = |path: &str| path.starts_with('/') || path.as_bytes().get(1) == Some(&b':');
+    let suffix = |long: &str, short: &str| {
+        long.strip_suffix(short)
+            .is_some_and(|prefix| prefix.ends_with('/'))
+    };
+    left == right
+        || (absolute(left) != absolute(right) && (suffix(left, right) || suffix(right, left)))
+}
+
+fn opcodes_match(left: &str, right: &str) -> bool {
+    let canonical = |opcode| match opcode {
+        "DIFFICULTY" => "PREVRANDAO",
+        "SHA3" => "KECCAK256",
+        other => other,
+    };
+    canonical(left).eq_ignore_ascii_case(canonical(right))
 }
 
 #[cfg(test)]
@@ -434,7 +605,10 @@ mod tests {
     use soldb_core::{TraceStep, TransactionTrace};
     use soldb_ethdebug::{EthdebugInfo, Instruction};
 
-    use super::{capture_debug_trace, compare_debug_traces, DebugDiffMode, DebugDifferenceKind};
+    use super::{
+        capture_debug_trace, compare_debug_traces, DebugCheckpoint, DebugDiffMode,
+        DebugDifferenceKind,
+    };
     use crate::ContractDebugInfo;
 
     const SOURCE: &str = "contract C {\n    function f() external {\n        uint256 x = 1;\n        x++;\n    }\n}\n";
@@ -569,7 +743,10 @@ mod tests {
 
         assert!(!report.equivalent);
         assert!(!report.comparable);
-        assert_eq!(report.diagnostics.len(), 2);
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|message| message == "reference trace has no source steps"));
     }
 
     #[test]
@@ -598,5 +775,131 @@ mod tests {
             capture_debug_trace(&candidate_trace, vec![contract(&[20], &[offset], "C.sol")]);
 
         assert!(compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 8).equivalent);
+    }
+
+    #[test]
+    fn mismatched_opcodes_and_missing_programs_cannot_pass() {
+        let offset = SOURCE.find("uint256").expect("statement");
+        let reference =
+            capture_debug_trace(&trace(&[0], "0x"), vec![contract(&[0], &[offset], "C.sol")]);
+        let mut wrong = trace(&[0], "0x");
+        wrong.steps[0].op = "INVALID".into();
+        let candidate = capture_debug_trace(&wrong, vec![contract(&[0], &[offset], "C.sol")]);
+        let report = compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 8);
+        assert!(!report.equivalent);
+        assert!(!report.comparable);
+        assert_eq!(report.difference_count, 0);
+        assert!(report.diagnostics[0].contains("trace opcode `INVALID`"));
+    }
+
+    #[test]
+    fn source_paths_and_contents_both_participate_in_identity() {
+        let offset = SOURCE.find("uint256").expect("statement");
+        let reference = capture_debug_trace(
+            &trace(&[0], "0x"),
+            vec![contract(&[0], &[offset], "a/C.sol")],
+        );
+        let candidate = capture_debug_trace(
+            &trace(&[0], "0x"),
+            vec![contract(&[0], &[offset], "b/C.sol")],
+        );
+        for mode in [DebugDiffMode::Steps, DebugDiffMode::Coverage] {
+            assert!(!compare_debug_traces(&reference, &candidate, mode, 8).equivalent);
+        }
+        let mut changed = contract(&[0], &[offset], "a/C.sol");
+        changed
+            .source_contents
+            .insert(0, SOURCE.replace("x = 1", "x = 2"));
+        let candidate = capture_debug_trace(&trace(&[0], "0x"), vec![changed]);
+        assert!(!compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 8).equivalent);
+    }
+
+    #[test]
+    fn constructors_compare_arguments_and_revert_data_not_initcode() {
+        let offset = SOURCE.find("uint256").expect("statement");
+        let mut left = trace(&[0], "0x6000");
+        left.to_addr = None;
+        left.input_data = "0x60000042".to_owned();
+        let mut right = left.clone();
+        right.input_data = "0x60010042".to_owned();
+        right.output = "0x6001".to_owned();
+        let mut reference = capture_debug_trace(&left, vec![contract(&[0], &[offset], "C.sol")]);
+        let mut candidate = capture_debug_trace(&right, vec![contract(&[0], &[offset], "C.sol")]);
+        assert!(!compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 8).equivalent);
+        assert!(candidate.set_constructor_args("0x99").is_err());
+        reference.set_constructor_args("0x0042").expect("arguments");
+        candidate.set_constructor_args("0x0042").expect("arguments");
+        assert!(compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 8).equivalent);
+        reference.execution.success = false;
+        candidate.execution.success = false;
+        assert!(
+            !compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 8)
+                .execution_equivalent
+        );
+    }
+
+    #[test]
+    fn checkpoints_cannot_hide_an_unreached_statement() {
+        let first = SOURCE.find("uint256").expect("statement");
+        let second = SOURCE.find("x++").expect("statement");
+        let mut reference = capture_debug_trace(
+            &trace(&[0, 1], "0x"),
+            vec![contract(&[0, 1], &[first, second], "C.sol")],
+        );
+        let mut candidate =
+            capture_debug_trace(&trace(&[0], "0x"), vec![contract(&[0], &[first], "C.sol")]);
+        let checkpoints = [DebugCheckpoint {
+            source: "C.sol".to_owned(),
+            line: 4,
+        }];
+        reference.retain_checkpoints(&checkpoints);
+        candidate.retain_checkpoints(&checkpoints);
+        let report = compare_debug_traces(&reference, &candidate, DebugDiffMode::Coverage, 8);
+        assert!(!report.equivalent);
+        assert!(!report.comparable);
+        assert_eq!(reference.events.len(), 1);
+        assert_eq!(candidate.events.len(), 0);
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|message| message == "candidate: checkpoint C.sol:4 was not reached"));
+    }
+
+    #[test]
+    fn partial_artifacts_and_invalid_ranges_cannot_pass() {
+        let offset = SOURCE.find("uint256").expect("statement");
+        let reference =
+            capture_debug_trace(&trace(&[0], "0x"), vec![contract(&[0], &[offset], "C.sol")]);
+        let partial = capture_debug_trace(
+            &trace(&[0, 99], "0x"),
+            vec![contract(&[0], &[offset], "C.sol")],
+        );
+        assert!(!compare_debug_traces(&reference, &partial, DebugDiffMode::Steps, 8).comparable);
+        let invalid = capture_debug_trace(
+            &trace(&[0], "0x"),
+            vec![contract(&[0], &[SOURCE.len() + 1], "C.sol")],
+        );
+        assert!(!compare_debug_traces(&reference, &invalid, DebugDiffMode::Steps, 8).comparable);
+    }
+
+    #[test]
+    fn a_single_instruction_body_is_not_smoothed_out() {
+        let declaration = SOURCE.find("function").expect("declaration");
+        let statement = SOURCE.find("uint256").expect("statement");
+        let mut captured = capture_debug_trace(
+            &trace(&[0, 1, 2], "0x"),
+            vec![contract(
+                &[0, 1, 2],
+                &[declaration, statement, declaration],
+                "C.sol",
+            )],
+        );
+        captured.retain_checkpoints(&[DebugCheckpoint {
+            source: "C.sol".to_owned(),
+            line: 3,
+        }]);
+        assert!(captured.diagnostics.is_empty());
+        assert_eq!(captured.events.len(), 1);
+        assert_eq!(captured.events[0].pc, 1);
     }
 }

--- a/crates/soldb-debugger/src/debug_diff.rs
+++ b/crates/soldb-debugger/src/debug_diff.rs
@@ -1,0 +1,602 @@
+//! Differential testing for the source-level debugging experience.
+//!
+//! Compilers need not emit the same bytecode for the same source, so comparing raw
+//! source maps or program counters says little about what a user sees. This module maps
+//! each execution through [`StepMap`], records the source stops exposed by `step`, and
+//! compares those normalized traces. The result is suitable for a test harness: it is
+//! deterministic, serializable, and separates execution differences from debug-info
+//! differences.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use soldb_core::TransactionTrace;
+
+use crate::{source_path_matches, ContractDebugInfo, StepMap};
+
+/// How strictly two source-level traces are compared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DebugDiffMode {
+    /// Compare ordered source lines, functions, frame depth, and frame entries.
+    Steps,
+    /// Compare steps and their exact source ranges and generated-code attribution.
+    Spans,
+    /// Compare the set of source lines and functions reached, ignoring order and depth.
+    Coverage,
+}
+
+/// The execution result whose debug information was captured.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugExecution {
+    pub creation: bool,
+    pub input: String,
+    pub value: String,
+    pub success: bool,
+    pub output: String,
+}
+
+/// Aggregate mapping quality for one side of a comparison.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugTraceSummary {
+    pub instructions: usize,
+    pub mapped_instructions: usize,
+    pub source_steps: usize,
+    pub frame_entries: usize,
+}
+
+/// One user-visible source stop in an execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugTraceEvent {
+    /// Instruction index in the original execution trace, for diagnostics only.
+    pub instruction: usize,
+    /// Program counter in that execution, for diagnostics only.
+    pub pc: u64,
+    pub contract: String,
+    pub source: String,
+    pub line: u64,
+    pub column: u64,
+    pub offset: u64,
+    pub length: u64,
+    pub function: Option<String>,
+    pub frame_depth: u32,
+    pub frame_entry: bool,
+    pub generated: bool,
+    /// Legacy source-map modifier depth, when the artifact carries it.
+    pub modifier_depth: Option<i64>,
+}
+
+/// A compiler-independent view of one execution's debugging experience.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugTrace {
+    pub execution: DebugExecution,
+    pub summary: DebugTraceSummary,
+    pub events: Vec<DebugTraceEvent>,
+}
+
+/// The kind of one sampled difference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DebugDifferenceKind {
+    Changed,
+    Missing,
+    Unexpected,
+}
+
+/// One difference between the reference and candidate source traces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugDifference {
+    pub kind: DebugDifferenceKind,
+    pub index: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference: Option<DebugTraceEvent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate: Option<DebugTraceEvent>,
+}
+
+/// Serializable result of a source-level differential.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugDiffReport {
+    pub schema_version: u32,
+    pub mode: DebugDiffMode,
+    pub equivalent: bool,
+    pub comparable: bool,
+    pub diagnostics: Vec<String>,
+    pub execution_equivalent: bool,
+    pub execution_differences: Vec<String>,
+    pub reference: DebugTraceSummary,
+    pub candidate: DebugTraceSummary,
+    pub difference_count: usize,
+    pub differences: Vec<DebugDifference>,
+    pub differences_truncated: bool,
+}
+
+/// Maps one execution to the source stops a debugger exposes.
+#[must_use]
+pub fn capture_debug_trace(
+    trace: &TransactionTrace,
+    contracts: Vec<ContractDebugInfo>,
+) -> DebugTrace {
+    let map = StepMap::new(trace, contracts);
+    let mut mapped_instructions = 0;
+    let mut frame_entries = 0;
+    let mut events = Vec::new();
+
+    for instruction in 0..map.step_count() {
+        if map.line_key(instruction).is_some() {
+            mapped_instructions += 1;
+        }
+        if map.is_frame_entry(instruction) {
+            frame_entries += 1;
+        }
+        if !map.is_line_start(instruction) {
+            continue;
+        }
+
+        let Some(location) = map.location(instruction) else {
+            continue;
+        };
+        let Some(step) = trace.steps.get(instruction) else {
+            continue;
+        };
+        let modifier_depth = map
+            .contract_at_step(instruction)
+            .and_then(|contract| contract.modifier_depth_at_pc(step.pc));
+        events.push(DebugTraceEvent {
+            instruction,
+            pc: step.pc,
+            contract: location.contract_name,
+            source: normalize_source_path(&location.path),
+            line: location.line,
+            column: location.column,
+            offset: location.offset,
+            length: location.length,
+            function: location.function_name,
+            frame_depth: map.frame_depth(instruction).unwrap_or(0),
+            frame_entry: map.is_frame_entry(instruction),
+            generated: location.generated,
+            modifier_depth,
+        });
+    }
+
+    DebugTrace {
+        execution: DebugExecution {
+            creation: trace.to_addr.is_none(),
+            input: normalize_hex_data(&trace.input_data),
+            value: normalize_quantity(&trace.value),
+            success: trace.success,
+            output: normalize_hex_data(&trace.output),
+        },
+        summary: DebugTraceSummary {
+            instructions: map.step_count(),
+            mapped_instructions,
+            source_steps: events.len(),
+            frame_entries,
+        },
+        events,
+    }
+}
+
+/// Compares two captured debugging experiences and samples at most `difference_limit`
+/// differences for display.
+#[must_use]
+pub fn compare_debug_traces(
+    reference: &DebugTrace,
+    candidate: &DebugTrace,
+    mode: DebugDiffMode,
+    difference_limit: usize,
+) -> DebugDiffReport {
+    let mut diagnostics = Vec::new();
+    if reference.events.is_empty() {
+        diagnostics.push("reference trace has no source steps".to_owned());
+    }
+    if candidate.events.is_empty() {
+        diagnostics.push("candidate trace has no source steps".to_owned());
+    }
+    let execution_differences = compare_execution(&reference.execution, &candidate.execution);
+    let (difference_count, differences) = match mode {
+        DebugDiffMode::Steps | DebugDiffMode::Spans => {
+            compare_ordered_events(&reference.events, &candidate.events, mode, difference_limit)
+        }
+        DebugDiffMode::Coverage => {
+            compare_coverage(&reference.events, &candidate.events, difference_limit)
+        }
+    };
+    let comparable = diagnostics.is_empty();
+    let execution_equivalent = execution_differences.is_empty();
+
+    DebugDiffReport {
+        schema_version: 1,
+        mode,
+        equivalent: comparable && execution_equivalent && difference_count == 0,
+        comparable,
+        diagnostics,
+        execution_equivalent,
+        execution_differences,
+        reference: reference.summary.clone(),
+        candidate: candidate.summary.clone(),
+        difference_count,
+        differences_truncated: difference_count > differences.len(),
+        differences,
+    }
+}
+
+fn compare_execution(reference: &DebugExecution, candidate: &DebugExecution) -> Vec<String> {
+    let mut differences = Vec::new();
+    if reference.creation != candidate.creation {
+        differences.push("execution kind differs".to_owned());
+    }
+    if reference.input != candidate.input {
+        differences.push("calldata differs".to_owned());
+    }
+    if reference.value != candidate.value {
+        differences.push("call value differs".to_owned());
+    }
+    if reference.success != candidate.success {
+        differences.push("success status differs".to_owned());
+    }
+    // Creation returns compiler-specific runtime bytecode, so differing output is not a
+    // behavioral mismatch between the constructors.
+    if !reference.creation && !candidate.creation && reference.output != candidate.output {
+        differences.push("return data differs".to_owned());
+    }
+    differences
+}
+
+fn compare_ordered_events(
+    reference: &[DebugTraceEvent],
+    candidate: &[DebugTraceEvent],
+    mode: DebugDiffMode,
+    limit: usize,
+) -> (usize, Vec<DebugDifference>) {
+    let mut difference_count = 0;
+    let mut differences = Vec::new();
+    for index in 0..reference.len().max(candidate.len()) {
+        let left = reference.get(index);
+        let right = candidate.get(index);
+        if matches!((left, right), (Some(left), Some(right)) if events_match(left, right, mode)) {
+            continue;
+        }
+
+        difference_count += 1;
+        if differences.len() == limit {
+            continue;
+        }
+        differences.push(DebugDifference {
+            kind: match (left, right) {
+                (Some(_), Some(_)) => DebugDifferenceKind::Changed,
+                (Some(_), None) => DebugDifferenceKind::Missing,
+                (None, Some(_)) => DebugDifferenceKind::Unexpected,
+                (None, None) => continue,
+            },
+            index,
+            reference: left.cloned(),
+            candidate: right.cloned(),
+        });
+    }
+    (difference_count, differences)
+}
+
+fn compare_coverage(
+    reference: &[DebugTraceEvent],
+    candidate: &[DebugTraceEvent],
+    limit: usize,
+) -> (usize, Vec<DebugDifference>) {
+    let reference = unique_coverage(reference);
+    let candidate = unique_coverage(candidate);
+    let mut candidate_by_core = BTreeMap::<CoverageCore<'_>, Vec<usize>>::new();
+    for (index, event) in candidate.iter().enumerate() {
+        candidate_by_core
+            .entry(CoverageCore::new(event))
+            .or_default()
+            .push(index);
+    }
+    let mut matched_candidate = BTreeSet::new();
+    let mut differences = Vec::new();
+    let mut difference_count = 0;
+
+    for (index, left) in reference.iter().enumerate() {
+        let right = candidate_by_core
+            .get(&CoverageCore::new(left))
+            .into_iter()
+            .flatten()
+            .find_map(|candidate_index| {
+                let right = candidate[*candidate_index];
+                (!matched_candidate.contains(candidate_index)
+                    && source_path_matches(&left.source, &right.source))
+                .then_some((*candidate_index, right))
+            });
+        if let Some((candidate_index, _)) = right {
+            matched_candidate.insert(candidate_index);
+            continue;
+        }
+        difference_count += 1;
+        if differences.len() < limit {
+            differences.push(DebugDifference {
+                kind: DebugDifferenceKind::Missing,
+                index,
+                reference: Some((*left).clone()),
+                candidate: None,
+            });
+        }
+    }
+
+    for (index, right) in candidate.iter().enumerate() {
+        if matched_candidate.contains(&index) {
+            continue;
+        }
+        difference_count += 1;
+        if differences.len() < limit {
+            differences.push(DebugDifference {
+                kind: DebugDifferenceKind::Unexpected,
+                index,
+                reference: None,
+                candidate: Some((*right).clone()),
+            });
+        }
+    }
+
+    (difference_count, differences)
+}
+
+fn unique_coverage(events: &[DebugTraceEvent]) -> Vec<&DebugTraceEvent> {
+    let mut keys = BTreeSet::new();
+    let mut unique = Vec::new();
+    for event in events {
+        if keys.insert((&event.contract, &event.source, event.line, &event.function)) {
+            unique.push(event);
+        }
+    }
+    unique
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct CoverageCore<'a> {
+    contract: &'a str,
+    line: u64,
+    function: Option<&'a str>,
+}
+
+impl<'a> CoverageCore<'a> {
+    fn new(event: &'a DebugTraceEvent) -> Self {
+        Self {
+            contract: &event.contract,
+            line: event.line,
+            function: event.function.as_deref(),
+        }
+    }
+}
+
+fn events_match(
+    reference: &DebugTraceEvent,
+    candidate: &DebugTraceEvent,
+    mode: DebugDiffMode,
+) -> bool {
+    let source_step = reference.contract == candidate.contract
+        && source_path_matches(&reference.source, &candidate.source)
+        && reference.line == candidate.line
+        && reference.function == candidate.function;
+    if mode == DebugDiffMode::Coverage {
+        return source_step;
+    }
+
+    source_step
+        && reference.frame_depth == candidate.frame_depth
+        && reference.frame_entry == candidate.frame_entry
+        && (mode != DebugDiffMode::Spans
+            || (reference.column == candidate.column
+                && reference.offset == candidate.offset
+                && reference.length == candidate.length
+                && reference.generated == candidate.generated
+                && reference.modifier_depth == candidate.modifier_depth))
+}
+
+fn normalize_source_path(path: &str) -> String {
+    let path = path.replace('\\', "/");
+    path.strip_prefix("./").unwrap_or(&path).to_owned()
+}
+
+fn normalize_hex_data(value: &str) -> String {
+    let value = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .unwrap_or(value);
+    format!("0x{}", value.to_ascii_lowercase())
+}
+
+fn normalize_quantity(value: &str) -> String {
+    if let Some(value) = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+    {
+        let value = value.trim_start_matches('0');
+        return format!("0x{}", if value.is_empty() { "0" } else { value });
+    }
+    let value = value.trim_start_matches('0');
+    if value.is_empty() {
+        "0".to_owned()
+    } else {
+        value.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use serde_json::json;
+    use soldb_core::{TraceStep, TransactionTrace};
+    use soldb_ethdebug::{EthdebugInfo, Instruction};
+
+    use super::{capture_debug_trace, compare_debug_traces, DebugDiffMode, DebugDifferenceKind};
+    use crate::ContractDebugInfo;
+
+    const SOURCE: &str = "contract C {\n    function f() external {\n        uint256 x = 1;\n        x++;\n    }\n}\n";
+
+    fn trace(pcs: &[u64], output: &str) -> TransactionTrace {
+        TransactionTrace {
+            tx_hash: None,
+            from_addr: "0x1".to_owned(),
+            to_addr: Some("0x2".to_owned()),
+            value: "0x0".to_owned(),
+            input_data: "0x26121ff0".to_owned(),
+            gas_used: 0,
+            output: output.to_owned(),
+            success: true,
+            error: None,
+            debug_trace_available: true,
+            contract_address: None,
+            backend: None,
+            capabilities: Default::default(),
+            artifacts: Default::default(),
+            steps: pcs
+                .iter()
+                .map(|pc| TraceStep {
+                    pc: *pc,
+                    op: "JUMPDEST".into(),
+                    gas: 0,
+                    gas_cost: 0,
+                    depth: 0,
+                    stack: Vec::new(),
+                    memory: None,
+                    storage: None,
+                    error: None,
+                    snapshot: Default::default(),
+                })
+                .collect(),
+        }
+    }
+
+    fn contract(pcs: &[u64], offsets: &[usize], path: &str) -> ContractDebugInfo {
+        let instructions = pcs
+            .iter()
+            .zip(offsets)
+            .map(|(pc, offset)| Instruction {
+                offset: *pc,
+                operation: json!({"mnemonic": "JUMPDEST"}),
+                context: Some(json!({
+                    "code": {
+                        "source": {"id": 0},
+                        "range": {"offset": offset, "length": 1}
+                    }
+                })),
+            })
+            .collect();
+        let info = EthdebugInfo {
+            compilation: json!({}),
+            contract_name: "C".to_owned(),
+            environment: "call".to_owned(),
+            instructions,
+            sources: BTreeMap::from([(0, path.to_owned())]),
+            variable_locations: BTreeMap::new(),
+        };
+        ContractDebugInfo::new(None, "C", info, BTreeMap::from([(0, SOURCE.to_owned())]))
+    }
+
+    #[test]
+    fn different_bytecode_with_the_same_source_steps_matches() {
+        let first = SOURCE.find("uint256").expect("statement");
+        let second = SOURCE.find("x++").expect("statement");
+        let reference = capture_debug_trace(
+            &trace(&[0, 1], "0x01"),
+            vec![contract(&[0, 1], &[first, second], "src/C.sol")],
+        );
+        let candidate = capture_debug_trace(
+            &trace(&[20, 24], "0x01"),
+            vec![contract(&[20, 24], &[first, second], "/checkout/src/C.sol")],
+        );
+
+        let report = compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 8);
+
+        assert!(report.equivalent);
+        assert_eq!(report.difference_count, 0);
+    }
+
+    #[test]
+    fn changed_steps_and_execution_are_reported_separately() {
+        let first = SOURCE.find("uint256").expect("statement");
+        let second = SOURCE.find("x++").expect("statement");
+        let reference = capture_debug_trace(
+            &trace(&[0, 1], "0x01"),
+            vec![contract(&[0, 1], &[first, second], "C.sol")],
+        );
+        let candidate = capture_debug_trace(
+            &trace(&[20, 24], "0x02"),
+            vec![contract(&[20, 24], &[second, first], "C.sol")],
+        );
+
+        let report = compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 1);
+
+        assert!(!report.equivalent);
+        assert!(!report.execution_equivalent);
+        assert_eq!(report.execution_differences, ["return data differs"]);
+        assert_eq!(report.difference_count, 2);
+        assert_eq!(report.differences.len(), 1);
+        assert!(report.differences_truncated);
+        assert_eq!(report.differences[0].kind, DebugDifferenceKind::Changed);
+    }
+
+    #[test]
+    fn coverage_ignores_order_and_repetition() {
+        let first = SOURCE.find("uint256").expect("statement");
+        let second = SOURCE.find("x++").expect("statement");
+        let reference = capture_debug_trace(
+            &trace(&[0, 0, 1, 1], "0x"),
+            vec![contract(&[0, 1], &[first, second], "C.sol")],
+        );
+        let candidate = capture_debug_trace(
+            &trace(&[20, 20, 24, 24], "0x"),
+            vec![contract(&[20, 24], &[second, first], "C.sol")],
+        );
+
+        let report = compare_debug_traces(&reference, &candidate, DebugDiffMode::Coverage, 8);
+
+        assert!(report.equivalent);
+    }
+
+    #[test]
+    fn empty_source_traces_are_not_comparable() {
+        let reference = capture_debug_trace(&trace(&[99], "0x"), Vec::new());
+        let candidate = capture_debug_trace(&trace(&[100], "0x"), Vec::new());
+
+        let report = compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 8);
+
+        assert!(!report.equivalent);
+        assert!(!report.comparable);
+        assert_eq!(report.diagnostics.len(), 2);
+    }
+
+    #[test]
+    fn span_mode_checks_exact_ranges_and_modifier_depth() {
+        let offset = SOURCE.find("uint256").expect("statement");
+        let reference =
+            capture_debug_trace(&trace(&[0], "0x"), vec![contract(&[0], &[offset], "C.sol")]);
+        let mut candidate = reference.clone();
+        candidate.events[0].length += 1;
+        candidate.events[0].modifier_depth = Some(1);
+
+        assert!(compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 8).equivalent);
+        assert!(!compare_debug_traces(&reference, &candidate, DebugDiffMode::Spans, 8).equivalent);
+    }
+
+    #[test]
+    fn execution_comparison_normalizes_hex_spelling() {
+        let offset = SOURCE.find("uint256").expect("statement");
+        let reference = capture_debug_trace(
+            &trace(&[0], "0xAB"),
+            vec![contract(&[0], &[offset], "C.sol")],
+        );
+        let mut candidate_trace = trace(&[20], "0Xab");
+        candidate_trace.value = "0x00".to_owned();
+        let candidate =
+            capture_debug_trace(&candidate_trace, vec![contract(&[20], &[offset], "C.sol")]);
+
+        assert!(compare_debug_traces(&reference, &candidate, DebugDiffMode::Steps, 8).equivalent);
+    }
+}

--- a/crates/soldb-debugger/src/lib.rs
+++ b/crates/soldb-debugger/src/lib.rs
@@ -27,8 +27,9 @@ pub mod stepping;
 
 pub use condition::{Condition, ConditionContext, Evaluation};
 pub use debug_diff::{
-    capture_debug_trace, compare_debug_traces, DebugDiffMode, DebugDiffReport, DebugDifference,
-    DebugDifferenceKind, DebugExecution, DebugTrace, DebugTraceEvent, DebugTraceSummary,
+    capture_debug_trace, compare_debug_traces, DebugCheckpoint, DebugDiffMode, DebugDiffReport,
+    DebugDifference, DebugDifferenceKind, DebugExecution, DebugTrace, DebugTraceEvent,
+    DebugTraceSummary,
 };
 pub use soldb_ethdebug::StorageLayout;
 pub use state::{

--- a/crates/soldb-debugger/src/lib.rs
+++ b/crates/soldb-debugger/src/lib.rs
@@ -21,10 +21,15 @@ use soldb_core::{StepSnapshot, TraceStep, TransactionTrace, Word as StackWord};
 use soldb_ethdebug::{decode_value, parse_word, EthdebugInfo, VariableLocation, Word};
 
 pub mod condition;
+pub mod debug_diff;
 pub mod state;
 pub mod stepping;
 
 pub use condition::{Condition, ConditionContext, Evaluation};
+pub use debug_diff::{
+    capture_debug_trace, compare_debug_traces, DebugDiffMode, DebugDiffReport, DebugDifference,
+    DebugDifferenceKind, DebugExecution, DebugTrace, DebugTraceEvent, DebugTraceSummary,
+};
 pub use soldb_ethdebug::StorageLayout;
 pub use state::{
     short_hex, state_value, state_variables, CachedChain, ChainRead, ChainStorage, StateSource,

--- a/crates/soldb-debugger/src/stepping.rs
+++ b/crates/soldb-debugger/src/stepping.rs
@@ -33,7 +33,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use soldb_core::{TransactionTrace, Word as StackWord};
 use soldb_ethdebug::{
-    function_selector, EthdebugInfo, FunctionExit, SourceLocation, StorageLayout,
+    function_selector, EthdebugInfo, FunctionExit, Instruction, SourceLocation, StorageLayout,
 };
 
 use crate::{
@@ -214,6 +214,12 @@ impl ContractDebugInfo {
     pub fn location_at_pc(&self, pc: u64) -> Option<SourceLocation> {
         let index = *self.pc_index.get(&pc)?;
         self.info.instructions.get(index)?.source_location()
+    }
+
+    /// The compiler's instruction at `pc`, using the prepared index.
+    #[must_use]
+    pub fn instruction_at_pc(&self, pc: u64) -> Option<&Instruction> {
+        self.info.instructions.get(*self.pc_index.get(&pc)?)
     }
 
     /// Legacy source-map modifier depth at `pc`, when the artifact carries it.
@@ -587,6 +593,19 @@ impl StepMap {
     /// it names, so a single `--ethdebug-dir` applies to the transaction it was passed for.
     #[must_use]
     pub fn new(trace: &TransactionTrace, contracts: Vec<ContractDebugInfo>) -> Self {
+        Self::build(trace, contracts, true)
+    }
+
+    /// Keeps single-instruction source stops when testing compiler debug information.
+    ///
+    /// Interactive stepping smooths brief line excursions. A compiler regression test
+    /// must observe them: an optimized getter can map its entire body to one `SLOAD`.
+    #[must_use]
+    pub fn for_debug_diff(trace: &TransactionTrace, contracts: Vec<ContractDebugInfo>) -> Self {
+        Self::build(trace, contracts, false)
+    }
+
+    fn build(trace: &TransactionTrace, contracts: Vec<ContractDebugInfo>, smooth: bool) -> Self {
         let mut addresses = Vec::<String>::new();
         let mut address_index = HashMap::<String, usize>::new();
         let mut intern = |address: &str| -> usize {
@@ -869,7 +888,9 @@ impl StepMap {
             reverted,
             argument_layouts,
         };
-        map.smooth_single_step_excursions();
+        if smooth {
+            map.smooth_single_step_excursions();
+        }
         map.mark_line_starts();
         map
     }

--- a/crates/soldb-debugger/src/stepping.rs
+++ b/crates/soldb-debugger/src/stepping.rs
@@ -216,6 +216,13 @@ impl ContractDebugInfo {
         self.info.instructions.get(index)?.source_location()
     }
 
+    /// Legacy source-map modifier depth at `pc`, when the artifact carries it.
+    #[must_use]
+    pub fn modifier_depth_at_pc(&self, pc: u64) -> Option<i64> {
+        let index = *self.pc_index.get(&pc)?;
+        self.info.instructions.get(index)?.modifier_depth()
+    }
+
     /// The narrowest parsed function whose declaration contains the span.
     #[must_use]
     pub fn function_for_location(&self, location: &SourceLocation) -> Option<usize> {

--- a/crates/soldb-ethdebug/src/metadata.rs
+++ b/crates/soldb-ethdebug/src/metadata.rs
@@ -104,6 +104,12 @@ impl Instruction {
             None
         }
     }
+
+    /// Legacy source-map modifier depth, when this instruction was adapted from one.
+    #[must_use]
+    pub fn modifier_depth(&self) -> Option<i64> {
+        self.context.as_ref()?.get("modifierDepth")?.as_i64()
+    }
 }
 
 fn collect_source_locations(context: &Value, locations: &mut Vec<SourceLocation>) {

--- a/crates/soldb-ethdebug/src/source_map.rs
+++ b/crates/soldb-ethdebug/src/source_map.rs
@@ -437,6 +437,7 @@ fn source_context(
     contract_name: &str,
 ) -> SoldbResult<Option<Value>> {
     let mut context = serde_json::Map::new();
+    context.insert("modifierDepth".to_owned(), json!(entry.modifier_depth));
     if let Some(code) = source_code(
         entry,
         source_count,
@@ -455,7 +456,7 @@ fn source_context(
         }
         _ => {}
     }
-    Ok((!context.is_empty()).then_some(Value::Object(context)))
+    Ok(Some(Value::Object(context)))
 }
 
 /// The `code` part of an entry's context: the source range it maps to, if any.
@@ -795,10 +796,11 @@ mod tests {
             .expect("runtime program");
         let at = |pc: u64| program.info.instruction_at_pc(pc).expect("instruction");
         assert_eq!(at(0).function_invocations().len(), 1);
+        assert_eq!(at(0).modifier_depth(), Some(0));
         assert_eq!(at(0).function_exit(), None);
         assert!(at(2).function_invocations().is_empty());
         assert_eq!(at(2).function_exit(), Some(FunctionExit::Return));
-        // Generated code without a range has no context when it does not jump.
+        // Generated code without a range still retains its modifier depth.
         assert!(at(4).source_location().is_none());
         assert!(at(4).function_invocations().is_empty());
     }

--- a/docs/debug-diff.md
+++ b/docs/debug-diff.md
@@ -1,0 +1,85 @@
+# Debug Information Differentials
+
+`soldb debug-diff` tests the debugging experience produced by two compiler
+outputs. It follows the central idea of LLVM's
+[Dexter](https://github.com/llvm/llvm-project/tree/main/cross-project-tests/debuginfo-tests/dexter):
+compare what a debugger presents while executing a program, not the raw debug
+records.
+
+Two Solidity compilers can generate different EVM programs for the same source.
+Their program counters and source-map strings therefore cannot be compared
+directly. The command instead builds the same `StepMap` used by the interactive
+debugger and DAP server, records each source-level step, and compares those
+records.
+
+## Compare Transactions
+
+Deploy the reference and candidate bytecode, send the same calldata and value to
+both contracts, then pass their transaction hashes and artifacts:
+
+```console
+soldb debug-diff \
+  --reference-tx 0xREFERENCE \
+  --candidate-tx 0xCANDIDATE \
+  --reference-ethdebug-dir 0xREF_ADDRESS:Counter:out-solc \
+  --candidate-ethdebug-dir 0xCANDIDATE_ADDRESS:Counter:out-candidate \
+  --rpc http://localhost:8545
+```
+
+The command separately compares calldata, call value, success status, and return
+data. A program-behavior difference is therefore reported as an execution
+difference rather than blamed on debug metadata.
+
+For contract-creation traces, returned runtime bytecode is intentionally not
+compared because different compilers are expected to deploy different programs.
+Constructor calldata, value, and success status are still checked.
+
+Each side also accepts a contract mapping through `--reference-contracts` or
+`--candidate-contracts`, and repeatable `--reference-source-path` and
+`--candidate-source-path` arguments for artifacts whose source paths are
+relative to their original build directories.
+
+## Comparison Modes
+
+`--mode steps` is the default. It compares the ordered source lines, containing
+functions, inferred call depth, and function entries that source stepping shows.
+Program counters and instruction indexes are retained only for diagnostics and
+do not participate in equality.
+
+`--mode spans` additionally compares byte offsets, lengths, columns,
+compiler-generated attribution, and legacy modifier depth. Use it when both
+compilers are expected to attribute expressions at the same granularity.
+
+`--mode coverage` compares unique source line and function pairs. It ignores
+order, repetition, and frame depth, which makes it useful when optimization
+legitimately inlines, merges, or reorders machine code while source coverage
+should remain intact.
+
+## Offline and CI Use
+
+For a hermetic test, pass serialized `TransactionTrace` values instead of
+transaction hashes:
+
+```console
+soldb debug-diff \
+  --reference-trace-file traces/reference.json \
+  --candidate-trace-file traces/candidate.json \
+  --reference-ethdebug-dir 0xREF_ADDRESS:Counter:out-solc \
+  --candidate-ethdebug-dir 0xCANDIDATE_ADDRESS:Counter:out-candidate \
+  --mode steps --json
+```
+
+Equivalent traces exit with status 0. Execution or debug-info differences exit
+with status 2, so the command can be used directly from lit, shell scripts, or
+CI. `--json` emits a stable report containing mapping summaries, the total
+difference count, and samples capped by `--max-differences`.
+
+A comparison with no source steps on either side is inconclusive and fails. It
+cannot turn missing or unusable debug metadata into a vacuous passing test; the
+JSON report sets `comparable` to `false` and explains which side lacked source
+steps.
+
+The library entry points are `soldb_debugger::capture_debug_trace` and
+`soldb_debugger::compare_debug_traces`. They take already loaded
+`TransactionTrace` and `ContractDebugInfo` values and perform no file or network
+I/O.

--- a/docs/debug-diff.md
+++ b/docs/debug-diff.md
@@ -8,9 +8,10 @@ records.
 
 Two Solidity compilers can generate different EVM programs for the same source.
 Their program counters and source-map strings therefore cannot be compared
-directly. The command instead builds the same `StepMap` used by the interactive
-debugger and DAP server, records each source-level step, and compares those
-records.
+directly. The command uses the debugger's `StepMap` with line smoothing disabled:
+even a single-instruction source stop participates, so an optimized `SLOAD`
+cannot disappear just because the interactive stepper smooths that excursion.
+It records those source steps and compares them.
 
 ## Compare Transactions
 
@@ -32,7 +33,11 @@ difference rather than blamed on debug metadata.
 
 For contract-creation traces, returned runtime bytecode is intentionally not
 compared because different compilers are expected to deploy different programs.
-Constructor calldata, value, and success status are still checked.
+Pass `--reference-constructor-args` and `--candidate-constructor-args` with the
+known ABI-encoded payload (`0x` for no arguments). Initcode cannot be compared as
+calldata because it includes compiler-specific code and data. The payload must
+match the end of each creation input; value, success, and failed-constructor
+revert data are still checked. Missing argument boundaries fail visibly.
 
 Each side also accepts a contract mapping through `--reference-contracts` or
 `--candidate-contracts`, and repeatable `--reference-source-path` and
@@ -55,10 +60,35 @@ order, repetition, and frame depth, which makes it useful when optimization
 legitimately inlines, merges, or reorders machine code while source coverage
 should remain intact.
 
+Use `--checkpoints-file checks.json` for Dexter-style test expectations:
+
+```json
+[{"source": "Counter.sol", "line": 12}, {"source": "Counter.sol", "line": 18}]
+```
+
+Both executions must reach every listed source line. Comparison then considers
+those stops in the selected mode. This permits tests to assert executable
+statements independently of compiler-specific declaration or prologue stops.
+An unreached checkpoint fails even when it is missing from both executions.
+Without this option, every debugger-visible stop participates in comparison.
+
+Source identity includes the exact content hash and normalized path. Two
+different paths do not match just because their basenames agree. Absolute paths
+may match a complete relative suffix; use common Standard JSON source names
+when comparing builds made in different checkouts.
+
+Every traced instruction in a supplied program must match its artifact opcode.
+Missing instructions, unidentified frames, duplicate PCs, unavailable source
+text, and out-of-bounds source ranges make the report inconclusive and fail.
+This validates the recorded opcodes, not a cryptographic identity of the full
+executed bytecode: PUSH immediates are not part of a trace step.
+
 ## Offline and CI Use
 
 For a hermetic test, pass serialized `TransactionTrace` values instead of
-transaction hashes:
+transaction hashes. `soldb run ... --save-trace trace.json` creates this format
+through local REVM execution. The normal `run --json` output remains the
+web-facing document:
 
 ```console
 soldb debug-diff \

--- a/test/cli/help.test
+++ b/test/cli/help.test
@@ -4,6 +4,7 @@
 # RUN: %soldb --version 2>&1 | FileCheck %s --check-prefix=VERSION
 # RUN: %soldb trace --help 2>&1 | FileCheck %s --check-prefix=TRACE
 # RUN: %soldb profile --help 2>&1 | FileCheck %s --check-prefix=PROFILE
+# RUN: %soldb debug-diff --help 2>&1 | FileCheck %s --check-prefix=DEBUG-DIFF
 # RUN: %soldb simulate --help 2>&1 | FileCheck %s --check-prefix=SIMULATE
 # RUN: %soldb list-events --help 2>&1 | FileCheck %s --check-prefix=EVENTS
 # RUN: %soldb list-contracts --help 2>&1 | FileCheck %s --check-prefix=CONTRACTS
@@ -15,6 +16,7 @@
 # MAIN-DAG: list-events
 # MAIN-DAG: trace
 # MAIN-DAG: profile
+# MAIN-DAG: debug-diff
 # MAIN-DAG: simulate
 
 # VERSION: soldb {{[0-9]+\.[0-9]+\.[0-9]+}}
@@ -34,6 +36,14 @@
 # PROFILE-DAG: --json
 # PROFILE-DAG: --folded
 # PROFILE-DAG: --flamegraph
+
+# DEBUG-DIFF-DAG: Usage:
+# DEBUG-DIFF-DAG: --reference-trace-file
+# DEBUG-DIFF-DAG: --candidate-trace-file
+# DEBUG-DIFF-DAG: --reference-ethdebug-dir
+# DEBUG-DIFF-DAG: --candidate-ethdebug-dir
+# DEBUG-DIFF-DAG: --mode
+# DEBUG-DIFF-DAG: --json
 
 # SIMULATE-DAG: Usage:
 # SIMULATE-DAG: --from

--- a/test/debug-diff/offline-debug-diff.test
+++ b/test/debug-diff/offline-debug-diff.test
@@ -1,8 +1,8 @@
 # Compare debugger-visible source steps without a node.
 # REQUIRES: soldb
-# RUN: %soldb debug-diff --reference-trace-file %{project_root}/test/fixtures/profile/trace.json --candidate-trace-file %{project_root}/test/fixtures/profile/trace.json --reference-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/profile --candidate-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/profile 2>&1 | FileCheck %s --check-prefix=MATCH
-# RUN: jq '.steps[].pc = 99' %{project_root}/test/fixtures/profile/trace.json > %t.trace
-# RUN: not %soldb debug-diff --reference-trace-file %{project_root}/test/fixtures/profile/trace.json --candidate-trace-file %t.trace --reference-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/profile --candidate-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/profile --json | jq '{equivalent, differenceCount, kind: .differences[0].kind}' | FileCheck %s --check-prefix=DIFFERENT
+# RUN: %soldb debug-diff --reference-trace-file %{project_root}/test/fixtures/debug-diff/trace.json --candidate-trace-file %{project_root}/test/fixtures/debug-diff/trace.json --reference-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/debug-diff --candidate-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/debug-diff 2>&1 | FileCheck %s --check-prefix=MATCH
+# RUN: jq '.steps[].pc = 99' %{project_root}/test/fixtures/debug-diff/trace.json > %t.trace
+# RUN: not %soldb debug-diff --reference-trace-file %{project_root}/test/fixtures/debug-diff/trace.json --candidate-trace-file %t.trace --reference-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/debug-diff --candidate-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/debug-diff --json | jq '{equivalent, differenceCount, kind: .differences[0].kind}' | FileCheck %s --check-prefix=DIFFERENT
 
 # MATCH: Debug Info Differential
 # MATCH: Reference: 1 source steps
@@ -12,3 +12,9 @@
 # DIFFERENT: "equivalent": false
 # DIFFERENT: "differenceCount": 1
 # DIFFERENT: "kind": "missing"
+
+# RUN: jq '.steps[].op = "INVALID"' %{project_root}/test/fixtures/debug-diff/trace.json > %t.trace
+# RUN: not %soldb debug-diff --reference-trace-file %{project_root}/test/fixtures/debug-diff/trace.json --candidate-trace-file %t.trace --reference-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/debug-diff --candidate-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/debug-diff --json | jq '{equivalent, comparable, diagnostic: .diagnostics[0]}' | FileCheck %s --check-prefix=INVALID
+# INVALID: "equivalent": false
+# INVALID: "comparable": false
+# INVALID: trace opcode `INVALID`

--- a/test/debug-diff/offline-debug-diff.test
+++ b/test/debug-diff/offline-debug-diff.test
@@ -1,0 +1,14 @@
+# Compare debugger-visible source steps without a node.
+# REQUIRES: soldb
+# RUN: %soldb debug-diff --reference-trace-file %{project_root}/test/fixtures/profile/trace.json --candidate-trace-file %{project_root}/test/fixtures/profile/trace.json --reference-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/profile --candidate-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/profile 2>&1 | FileCheck %s --check-prefix=MATCH
+# RUN: jq '.steps[].pc = 99' %{project_root}/test/fixtures/profile/trace.json > %t.trace
+# RUN: not %soldb debug-diff --reference-trace-file %{project_root}/test/fixtures/profile/trace.json --candidate-trace-file %t.trace --reference-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/profile --candidate-ethdebug-dir 0x000000000000000000000000000000000000cafe:Counter:%{project_root}/test/fixtures/profile --json | jq '{equivalent, differenceCount, kind: .differences[0].kind}' | FileCheck %s --check-prefix=DIFFERENT
+
+# MATCH: Debug Info Differential
+# MATCH: Reference: 1 source steps
+# MATCH: Candidate: 1 source steps
+# MATCH: Result: MATCH
+
+# DIFFERENT: "equivalent": false
+# DIFFERENT: "differenceCount": 1
+# DIFFERENT: "kind": "missing"

--- a/test/debug-diff/save-trace.test
+++ b/test/debug-diff/save-trace.test
@@ -1,0 +1,7 @@
+# Local execution exports the raw trace format consumed by debug-diff.
+# REQUIRES: soldb
+# RUN: %soldb run 600160005260206000f3 --runtime --raw-data 0x --save-trace %t.trace --json > %t.web
+# RUN: jq '{success, input_data, steps: (.steps | length)}' %t.trace | FileCheck %s
+# CHECK: "success": true
+# CHECK: "input_data": "0x"
+# CHECK: "steps": 6

--- a/test/fixtures/debug-diff/Counter_ethdebug-runtime.json
+++ b/test/fixtures/debug-diff/Counter_ethdebug-runtime.json
@@ -1,0 +1,17 @@
+{
+  "compilation": {"id": "debug-diff-fixture"},
+  "contract": {"name": "Counter"},
+  "environment": "call",
+  "instructions": [
+    {
+      "offset": 0,
+      "operation": {"mnemonic": "PUSH1", "arguments": ["0x01"]},
+      "context": {"code": {"source": {"id": 0}, "range": {"offset": 57, "length": 13}}}
+    },
+    {
+      "offset": 2,
+      "operation": {"mnemonic": "ADD"},
+      "context": {"code": {"source": {"id": 0}, "range": {"offset": 57, "length": 13}}}
+    }
+  ]
+}

--- a/test/fixtures/debug-diff/ethdebug_resources.json
+++ b/test/fixtures/debug-diff/ethdebug_resources.json
@@ -1,0 +1,13 @@
+{
+  "compilation": {
+    "id": "debug-diff-fixture",
+    "compiler": {"name": "fixture", "version": "1"},
+    "sources": [{
+      "id": 0,
+      "path": "Counter.sol",
+      "contents": "contract Counter {\n    function add() external {\n        uint256 x = 1;\n    }\n}\n"
+    }]
+  },
+  "types": {},
+  "pointers": {}
+}

--- a/test/fixtures/debug-diff/trace.json
+++ b/test/fixtures/debug-diff/trace.json
@@ -1,0 +1,17 @@
+{
+  "tx_hash": null,
+  "from_addr": "0x0000000000000000000000000000000000000001",
+  "to_addr": "0x000000000000000000000000000000000000cafe",
+  "value": "0",
+  "input_data": "0x",
+  "gas_used": 21006,
+  "output": "0x",
+  "success": true,
+  "error": null,
+  "debug_trace_available": true,
+  "contract_address": null,
+  "steps": [
+    {"pc": 0, "op": "PUSH1", "gas": 1000, "gas_cost": 3, "depth": 0, "stack": [], "memory": null, "storage": null, "error": null},
+    {"pc": 2, "op": "ADD", "gas": 997, "gas_cost": 3, "depth": 0, "stack": [], "memory": null, "storage": null, "error": null}
+  ]
+}

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -16,6 +16,7 @@ NC='\033[0m'
 # Parse command line arguments
 RUN_TRACE_TESTS=true
 RUN_PROFILE_TESTS=true
+RUN_DEBUG_DIFF_TESTS=true
 RUN_SIMULATE_TESTS=true
 RUN_RUN_TESTS=true
 RUN_EVENTS_TESTS=true
@@ -36,6 +37,7 @@ for arg in "$@"; do
             ;;
         --trace-only)
             RUN_PROFILE_TESTS=false
+            RUN_DEBUG_DIFF_TESTS=false
             RUN_SIMULATE_TESTS=false
             RUN_EVENTS_TESTS=false
             RUN_CLI_TESTS=false
@@ -44,6 +46,16 @@ for arg in "$@"; do
             ;;
         --profile-only)
             RUN_TRACE_TESTS=false
+            RUN_DEBUG_DIFF_TESTS=false
+            RUN_SIMULATE_TESTS=false
+            RUN_EVENTS_TESTS=false
+            RUN_CLI_TESTS=false
+            RUN_RUN_TESTS=false
+            shift
+            ;;
+        --debug-diff-only)
+            RUN_TRACE_TESTS=false
+            RUN_PROFILE_TESTS=false
             RUN_SIMULATE_TESTS=false
             RUN_EVENTS_TESTS=false
             RUN_CLI_TESTS=false
@@ -53,6 +65,7 @@ for arg in "$@"; do
         --simulate-only)
             RUN_TRACE_TESTS=false
             RUN_PROFILE_TESTS=false
+            RUN_DEBUG_DIFF_TESTS=false
             RUN_EVENTS_TESTS=false
             RUN_CLI_TESTS=false
             RUN_RUN_TESTS=false
@@ -61,6 +74,7 @@ for arg in "$@"; do
         --events-only)
             RUN_TRACE_TESTS=false
             RUN_PROFILE_TESTS=false
+            RUN_DEBUG_DIFF_TESTS=false
             RUN_SIMULATE_TESTS=false
             RUN_CLI_TESTS=false
             RUN_RUN_TESTS=false
@@ -69,6 +83,7 @@ for arg in "$@"; do
         --run-only)
             RUN_TRACE_TESTS=false
             RUN_PROFILE_TESTS=false
+            RUN_DEBUG_DIFF_TESTS=false
             RUN_SIMULATE_TESTS=false
             RUN_EVENTS_TESTS=false
             RUN_CLI_TESTS=false
@@ -77,6 +92,7 @@ for arg in "$@"; do
         --cli-only)
             RUN_TRACE_TESTS=false
             RUN_PROFILE_TESTS=false
+            RUN_DEBUG_DIFF_TESTS=false
             RUN_SIMULATE_TESTS=false
             RUN_EVENTS_TESTS=false
             RUN_RUN_TESTS=false
@@ -97,6 +113,7 @@ for arg in "$@"; do
             echo "Options:"
             echo "  --trace-only       Run only trace tests (from test/trace/)"
             echo "  --profile-only     Run only profile tests (from test/profile/)"
+            echo "  --debug-diff-only  Run only debug-diff tests (from test/debug-diff/)"
             echo "  --simulate-only    Run only simulate tests (from test/simulate/)"
             echo "  --run-only         Run only run tests (from test/run/)"
             echo "  --events-only      Run only events tests (from test/events/)"
@@ -110,6 +127,7 @@ for arg in "$@"; do
             echo "Test Structure:"
             echo "  test/trace/        Contains trace command tests"
             echo "  test/profile/      Contains profile command tests"
+            echo "  test/debug-diff/   Contains debug-info differential tests"
             echo "  test/simulate/     Contains simulate command tests"
             echo "  test/run/          Contains run command tests (no node needed)"
             echo "  test/events/       Contains list-events command tests"
@@ -126,6 +144,7 @@ for arg in "$@"; do
             echo "  $0                           # Run all tests"
             echo "  $0 --trace-only              # Run only trace tests"
             echo "  $0 --profile-only            # Run only profile tests"
+            echo "  $0 --debug-diff-only         # Run only debug-info differential tests"
             echo "  $0 --simulate-only           # Run only simulate tests"
             echo "  $0 --events-only             # Run only events tests"
             echo "  $0 -v                        # Run all tests with verbose output"
@@ -262,6 +281,7 @@ echo -e "${GREEN}=== SolDB Test Suite ===${NC}"
 echo -e "${GREEN}Organized test structure:${NC}"
 echo -e "${GREEN}  - test/trace/     : Trace command tests${NC}"
 echo -e "${GREEN}  - test/profile/   : Profile command tests${NC}"
+echo -e "${GREEN}  - test/debug-diff/: Debug-info differential tests${NC}"
 echo -e "${GREEN}  - test/simulate/  : Simulate command tests${NC}"
 echo -e "${GREEN}  - test/run/       : Run command tests (local chain, no node)${NC}"
 echo -e "${GREEN}  - test/events/    : List-events command tests${NC}"
@@ -545,6 +565,17 @@ if [ "$RUN_PROFILE_TESTS" = true ]; then
         "$LIT_CMD" $LIT_OPTS "${SCRIPT_DIR}/profile"
     else
         echo -e "${YELLOW}Warning: profile directory not found${NC}"
+    fi
+fi
+
+# Run source-level debug-info differentials. These fixtures are hermetic and use
+# serialized traces, but share the lit configuration with the rest of the suite.
+if [ "$RUN_DEBUG_DIFF_TESTS" = true ]; then
+    echo -e "${YELLOW}Running debug-info differential tests...${NC}"
+    if [ -d "${SCRIPT_DIR}/debug-diff" ]; then
+        "$LIT_CMD" $LIT_OPTS "${SCRIPT_DIR}/debug-diff"
+    else
+        echo -e "${YELLOW}Warning: debug-diff directory not found${NC}"
     fi
 fi
 


### PR DESCRIPTION
Add a Dexter-style (from LLVM) differential runner over debugger-visible source steps.