### PR TITLE
Fix parameter list parsing and lit PYTHONPATH

### DIFF
--- a/crates/soldb-debugger/src/lib.rs
+++ b/crates/soldb-debugger/src/lib.rs
@@ -792,8 +792,12 @@ fn collect_declarations(
     }
 }
 
+/// The words that may follow a parameter's type without naming it.
+const PARAM_KEYWORDS: [&str; 4] = ["memory", "calldata", "storage", "payable"];
+
 fn parse_source_params(params: &str) -> Vec<SourceParam> {
-    split_top_level_commas(params)
+    let params = strip_param_comments(params);
+    split_top_level_commas(&params)
         .into_iter()
         .enumerate()
         .filter_map(|(index, param)| {
@@ -802,26 +806,91 @@ fn parse_source_params(params: &str) -> Vec<SourceParam> {
                 return None;
             }
             let mut tokens = param.split_whitespace().collect::<Vec<_>>();
-            let name = tokens
-                .last()
-                .copied()
-                .filter(|token| is_identifier(token))
-                .map_or_else(|| format!("arg{index}"), str::to_owned);
-            if tokens.last().copied() == Some(name.as_str()) && tokens.len() > 1 {
-                tokens.pop();
-            }
+            // A parameter is `<type> [location] [name]`, and the name is optional:
+            // `function f(address, uint256 amount)` leaves the first one unnamed. A
+            // trailing token names the parameter only when it is an identifier, is not
+            // the whole parameter, and is not one of the words that may follow a type
+            // without naming it; otherwise the parameter is unnamed and takes `argN`.
+            let trailing = tokens.last().copied();
+            let name = match trailing {
+                Some(token)
+                    if tokens.len() > 1
+                        && is_identifier(token)
+                        && !PARAM_KEYWORDS.contains(&token) =>
+                {
+                    tokens.pop();
+                    token.to_owned()
+                }
+                _ => format!("arg{index}"),
+            };
             let location = tokens
                 .iter()
                 .find(|token| matches!(**token, "memory" | "calldata" | "storage"))
                 .map(|token| (*token).to_owned());
             let ty = tokens
                 .into_iter()
-                .filter(|token| !matches!(*token, "memory" | "calldata" | "storage" | "payable"))
+                .filter(|token| !PARAM_KEYWORDS.contains(token))
                 .collect::<Vec<_>>()
                 .join(" ");
             (!ty.is_empty()).then_some(SourceParam { name, ty, location })
         })
         .collect()
+}
+
+/// A parameter list with its comments removed.
+///
+/// Solidity allows a comment anywhere in a parameter list, and an unnamed parameter is
+/// commonly documented with one:
+///
+/// ```solidity
+/// function burnFrom_withCaller(
+///     address caller,
+///     address, //from
+///     uint256, //amount
+/// ) external {}
+/// ```
+///
+/// Left in, a comment's words are split on whitespace like any other token, so `//from`
+/// parses as a type and the type on the following line parses as its name. Only the text
+/// between the parentheses is stripped, so no byte offset recorded for a declaration
+/// moves.
+fn strip_param_comments(params: &str) -> String {
+    let mut output = String::with_capacity(params.len());
+    let mut chars = params.chars().peekable();
+    while let Some(character) = chars.next() {
+        if character == '/' {
+            match chars.peek() {
+                Some('/') => {
+                    // Drop to the end of the line, keeping the newline so the tokens on
+                    // either side of it stay separate.
+                    for next in chars.by_ref() {
+                        if next == '\n' {
+                            output.push('\n');
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                Some('*') => {
+                    chars.next();
+                    let mut previous = None;
+                    for next in chars.by_ref() {
+                        if previous == Some('*') && next == '/' {
+                            break;
+                        }
+                        previous = Some(next);
+                    }
+                    // A block comment can sit between a type and its name, so it leaves
+                    // a separator behind rather than joining them.
+                    output.push(' ');
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        output.push(character);
+    }
+    output
 }
 
 fn split_top_level_commas(input: &str) -> Vec<&str> {
@@ -1121,6 +1190,111 @@ mod tests {
         assert_eq!(functions[0].params[0].ty, "Person");
         assert_eq!(functions[0].params[1].name, "xs");
         assert_eq!(functions[0].params[1].ty, "uint256[2]");
+    }
+
+    #[test]
+    fn unnamed_params_documented_by_comments_do_not_become_parameters() {
+        // The shape this comes from, verbatim: unnamed parameters whose names live in
+        // trailing comments. Before comments were stripped, `//from` parsed as a type and
+        // the type on the next line parsed as its name.
+        let functions = parse_source_functions(
+            0,
+            "contract C {\n    function burnFrom_withCaller(\n        address caller,\n                     address, //from\n        uint256, //amount\n        bytes32 //h\n    ) external              view returns (bool) {}\n}",
+        );
+        let params = &functions[0].params;
+        assert_eq!(functions[0].name, "burnFrom_withCaller");
+        assert_eq!(params.len(), 4);
+        assert_eq!(
+            (params[0].ty.as_str(), params[0].name.as_str()),
+            ("address", "caller")
+        );
+        assert_eq!(
+            (params[1].ty.as_str(), params[1].name.as_str()),
+            ("address", "arg1")
+        );
+        assert_eq!(
+            (params[2].ty.as_str(), params[2].name.as_str()),
+            ("uint256", "arg2")
+        );
+        assert_eq!(
+            (params[3].ty.as_str(), params[3].name.as_str()),
+            ("bytes32", "arg3")
+        );
+    }
+
+    #[test]
+    fn unnamed_params_take_positional_names_not_their_type() {
+        let functions = parse_source_functions(
+            0,
+            "contract C { function burn(address from, uint256 amount, bytes32, bytes memory              signature) public {} }",
+        );
+        let params = &functions[0].params;
+        assert_eq!(
+            (params[1].ty.as_str(), params[1].name.as_str()),
+            ("uint256", "amount")
+        );
+        // Previously reported as `bytes32 bytes32`, the type standing in as the name.
+        assert_eq!(
+            (params[2].ty.as_str(), params[2].name.as_str()),
+            ("bytes32", "arg2")
+        );
+        assert_eq!(
+            (params[3].ty.as_str(), params[3].name.as_str()),
+            ("bytes", "signature")
+        );
+        assert_eq!(params[3].location.as_deref(), Some("memory"));
+    }
+
+    #[test]
+    fn a_trailing_declaration_keyword_does_not_name_a_param() {
+        let functions = parse_source_functions(
+            0,
+            "contract C { function f(string memory, address payable, bytes calldata data) public              {} }",
+        );
+        let params = &functions[0].params;
+        assert_eq!(
+            (params[0].ty.as_str(), params[0].name.as_str()),
+            ("string", "arg0")
+        );
+        assert_eq!(params[0].location.as_deref(), Some("memory"));
+        assert_eq!(
+            (params[1].ty.as_str(), params[1].name.as_str()),
+            ("address", "arg1")
+        );
+        assert_eq!(
+            (params[2].ty.as_str(), params[2].name.as_str()),
+            ("bytes", "data")
+        );
+        assert_eq!(params[2].location.as_deref(), Some("calldata"));
+    }
+
+    #[test]
+    fn block_comments_in_a_param_list_separate_rather_than_join() {
+        let functions = parse_source_functions(
+            0,
+            "contract C { function f(uint256 /* wei */ amount, address /*to*/) public {} }",
+        );
+        let params = &functions[0].params;
+        assert_eq!(
+            (params[0].ty.as_str(), params[0].name.as_str()),
+            ("uint256", "amount")
+        );
+        assert_eq!(
+            (params[1].ty.as_str(), params[1].name.as_str()),
+            ("address", "arg1")
+        );
+    }
+
+    #[test]
+    fn stripping_comments_leaves_declaration_offsets_alone() {
+        // Only the text between the parentheses is stripped, so the offsets the PC
+        // mapping reads still point into the original source.
+        let source = "contract C {\n    function f(address, //from\n        uint256 amount\n                          ) public {}\n}";
+        let functions = parse_source_functions(0, source);
+        let start = functions[0].declaration_start as usize;
+        assert!(source[start..].starts_with("function f("));
+        assert_eq!(functions[0].declaration_line, 2);
+        assert_eq!(source.as_bytes()[functions[0].body_end as usize], b'}');
     }
 
     fn sample_trace() -> TransactionTrace {

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -5,7 +5,6 @@ import os
 import platform
 import shlex
 import subprocess
-import sys
 
 import lit.formats
 
@@ -163,4 +162,11 @@ for env_var in ('COVERAGE_FILE', 'COVERAGE_RCFILE'):
     if env_var in os.environ:
         config.environment[env_var] = os.environ[env_var]
 
-config.environment['PYTHONPATH'] = os.pathsep.join(sys.path)
+# Do not export lit's own sys.path as PYTHONPATH. Tests run `solc`, and a solc-select
+# install is a Python script with its own interpreter; handing it the stdlib of the
+# interpreter running lit makes it import that stdlib instead of its own, which fails at
+# `assert _sre.MAGIC == MAGIC` the moment the two versions differ. The result is a compile
+# that dies for a reason having nothing to do with the test, and `increment-trace.test`
+# recompiles into `examples/out` after deleting it, so every later test that reads those
+# artifacts fails too. Nothing here needs the variable: the tests that run Python use only
+# the standard library.


### PR DESCRIPTION
Two independent fixes, the second found while testing the first.

## `soldb-debugger`: parameter list parsing

`parse_source_params` split a parameter list on whitespace with its
comments still in it, and treated any trailing identifier as the
parameter's name. Solidity allows both a comment inside the list and a
parameter declared without a name, and a contract using both rendered
its frames like this:

```
#13 recover_withCaller(address caller, address address, //from address, //to bytes32, //h uint8, //v bytes32, //r bytes32 //s arg6)
#6  burn(address from, uint256 amount, bytes32 bytes32, bytes signature)
```

from source that reads:

```solidity
function recover_withCaller(
    address caller,
    address, //from
    address, //to
    ...
```

Now:

```
#13 recover_withCaller(address caller, address arg1, address arg2, bytes32 arg3, uint8 arg4, bytes32 arg5, bytes32 arg6)
#6  burn(address from, uint256 amount, bytes32 arg2, bytes signature)
```

Comments are stripped from the parameter text before it is split, and a
trailing token names the parameter only when it is an identifier, is not
the whole parameter, and is not one of `memory`, `calldata`, `storage`,
`payable`. Only the text between the parentheses is touched, so no
offset the PC mapping reads moves; one of the five new unit tests pins
that.

## `test/lit.cfg.py`: PYTHONPATH

lit exported its own `sys.path` as `PYTHONPATH` to every test
subprocess. A solc-select `solc` is a Python script with its own
interpreter, so when lit's Python differs from solc-select's, solc
imports the wrong stdlib and dies at `assert _sre.MAGIC == MAGIC`.
Because `increment-trace.test` deletes `examples/out` before recompiling
into it, the delete succeeded and the compile did not, and nine later
tests failed reading artifacts that were no longer there — none of them
pointing at the cause.

The variable is a leftover from the Python implementation; it survived
59b02f2. Nothing needs it, and `auto-backend-fallback.test` already
carried an `env -u PYTHONPATH` workaround for the same hazard.

## Testing

Rust: workspace tests pass, clippy `-D warnings` clean, `fmt --check`
clean.

lit, run against anvil with the solc-select shim as `solc` on PATH and
no workaround. Before the PYTHONPATH change this same configuration
produced nine failures and left `examples/out` holding only
`compile.log`:

| suite | result |
| --- | --- |
| trace | 14 passed, 3 unsupported (sepolia, stylus), 4 failed |
| simulate | 13 passed, 1 unsupported |
| run | 10 passed |
| events | 7 passed, 2 unsupported |
| cli | 6 passed |
| profile | 2 passed |
| debug-diff | 2 passed |

The four trace failures are environmental rather than from these
changes: the node was on port 8546 because 8545 was occupied, and
`create-replay-parity-tx.sh` defaults to 8545 while `lit.cfg.py`
forwards only `COVERAGE_*`, so those tests sent their transactions to
one node and looked for them on another. Re-run against the right
endpoint all four pass in full — opcode parity identical (230, 625 and
134 ops), SLOAD/SSTORE snapshot parity identical, every FileCheck
assertion met.
