### PR TITLE
docs: point the README screenshot at assets/soldb-tui.png

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 SolDB is an open-source, ETHDebug-first, LLDB-style debugger for Solidity and the EVM.
 
-![SolDB full-screen view](docs/assets/soldb-tui.png)
+![SolDB full-screen view](assets/soldb-tui.png)
 
 ---
 


### PR DESCRIPTION
The main image referenced `docs/assets/soldb-tui.png`, but the screenshot is committed at `assets/soldb-tui.png`, so GitHub rendered a broken image. Point the README at the file that exists.


